### PR TITLE
Configuration Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.bundle/
 /.env
+/.rspec_status
 /.yardoc
 /_yardoc/
 /coverage/

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,8 @@ PATH
   remote: .
   specs:
     multi-background-job (0.1.0)
+      connection_pool
+      multi_json
       redis
 
 GEM
@@ -9,9 +11,11 @@ GEM
   specs:
     awesome_print (1.8.0)
     coderay (1.1.3)
+    connection_pool (2.2.3)
     diff-lcs (1.4.4)
     dotenv (2.7.6)
     method_source (1.0.0)
+    multi_json (1.15.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)

--- a/lib/multi_background_job.rb
+++ b/lib/multi_background_job.rb
@@ -1,3 +1,25 @@
 # frozen_string_literal: true
 
 require_relative './multi_background_job/version'
+require_relative 'multi_background_job/errors'
+require_relative 'multi_background_job/config'
+
+module MultiBackgroundJob
+  def self.config
+    @config ||= Config.new
+  end
+
+  def self.configure(&block)
+    return unless block_given?
+
+    config.instance_eval(&block)
+    @redis_pool = nil
+    config
+  end
+
+  def self.redis_pool
+    @redis_pool ||= ConnectionPool.new(config.redis_pool) do
+      Redis.new(config.redis_config)
+    end
+  end
+end

--- a/lib/multi_background_job/config.rb
+++ b/lib/multi_background_job/config.rb
@@ -1,0 +1,135 @@
+# frizen_string_literal: true
+
+require 'redis'
+require 'connection_pool'
+
+module MultiBackgroundJob
+  class Config
+    class << self
+      private
+
+      def attribute_accessor(field, validator: nil, normalizer: nil, default: nil)
+        normalizer ||= :"normalize_#{field}"
+        validator ||= :"validate_#{field}"
+
+        define_method(field) do
+          unless instance_variable_defined?(:"@#{field}")
+            fallback =  default #config_from_yaml[field.to_s] ||
+            return unless fallback
+
+            send(:"#{field}=", fallback.respond_to?(:call) ? fallback.call : fallback)
+          end
+          instance_variable_get(:"@#{field}")
+        end
+
+        define_method(:"#{field}=") do |value|
+          value = send(normalizer, field, value) if respond_to?(normalizer, true)
+          send(validator, field, value) if respond_to?(validator, true)
+
+          instance_variable_set(:"@#{field}", value)
+        end
+      end
+    end
+
+    # ConnectionPool options for redis
+    attribute_accessor :redis_pool_size, default: 5, normalizer: :normalize_to_int, validator: :validate_greater_than_zero
+    attribute_accessor :redis_pool_timeout, default: 5, normalizer: :normalize_to_int, validator: :validate_greater_than_zero
+
+    # Namespace used to manage internal data like unique job verification data.
+    attribute_accessor :redis_namespace, default: 'multi-bg'
+
+    # List of configurations to be passed along to the Redis.new
+    attribute_accessor :redis_config, default: {}
+
+    # Path to the YAML file with configs
+    attribute_accessor :config_path, default: 'config/background_job.yml'
+
+    # A Hash with all workers definitions. The worker class name must be the main hash key
+    # Example:
+    #   "Accounts::ConfirmationEmailWorker":
+    #     retry: false
+    #     queue: "mailer"
+    #   "Elastic::BatchIndex":
+    #     retry: 5
+    #     queue: "elasticsearch"
+    #     adapter: "faktory"
+    attribute_accessor :workers, default: {}
+
+    # Does not validate if it's  when set to false
+    attribute_accessor :strict, default: true
+    alias strict? strict
+
+    def worker_options(class_name)
+      class_name = class_name.to_s
+      if strict? && !workers.key?(class_name)
+        raise NotDefinedWorker.new(class_name)
+      end
+
+      workers.fetch(class_name, {})
+    end
+
+    def redis_pool
+      {
+        size: redis_pool_size,
+        timeout: redis_pool_timeout,
+      }
+    end
+
+    private
+
+    def normalize_to_int(_attribute, value)
+      value.to_i
+    end
+
+    def validate_greater_than_zero(attribute, value)
+      return if value > 0
+
+      raise InvalidConfig, format(
+        'The %<value>p for %<attr>s is not valid. It must be greater than zero',
+        value: value,
+        attr: attribute,
+      )
+    end
+
+    def normalize_redis_config(_attribute, value)
+      case value
+      when String
+        { url: value }
+      when Hash
+        value.each_with_object({}) { |(k, v), r| r[k.to_sym] = v }
+      else
+        value
+      end
+    end
+
+    def validate_redis_config(attribute, value)
+      return if value.is_a?(Hash)
+
+      raise InvalidConfig, format(
+        'The %<value>p for %<attr>i is not valid. It must be a Hash with the redis initialization options. ' +
+        'See https://github.com/redis/redis-rb for all available options',
+        value: value,
+        attr: attribute,
+      )
+    end
+
+    def normalize_workers(_, value)
+      return unless value.is_a?(Hash)
+
+      hash = {}
+      value.each do |class_name, opts|
+        hash[class_name.to_s] = opts.each_with_object({}) { |(k,v), r| r[k.to_sym] = v }
+      end
+      hash
+    end
+
+    def config_from_yaml
+      @config ||= begin
+        YAML.load_file(config_path)
+      rescue Errno::ENOENT, Errno::ESRCH
+        {}
+      end
+    end
+  end
+end
+

--- a/multi-background-job.gemspec
+++ b/multi-background-job.gemspec
@@ -34,4 +34,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'redis', '>= 0.0.0'
+  spec.add_dependency 'connection_pool', '>= 0.0.0'
+  spec.add_dependency 'multi_json', '>= 0.0.0'
 end

--- a/spec/multi_background_job/config_spec.rb
+++ b/spec/multi_background_job/config_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe MultiBackgroundJob::Config do
+  let(:config) { described_class.new }
+
+  describe 'default values' do
+    it { expect(config.redis_pool_size).to eq(5) }
+    it { expect(config.redis_pool_timeout).to eq(5) }
+    it { expect(config.redis_namespace).to eq('multi-bg') }
+    it { expect(config.redis_config).to eq({}) }
+    it { expect(config.config_path).to eq('config/background_job.yml') }
+  end
+
+  describe '.redis_pool_size=' do
+    it 'converts value to interger' do
+      config.redis_pool_size = '10'
+      expect(config.redis_pool_size).to eq(10)
+    end
+
+    it 'does not allow lower than zero' do
+      msg = -> (v) { "The #{v.inspect} for redis_pool_size is not valid. It must be greater than zero" }
+      expect { config.redis_pool_size = '0' }.to raise_error(MultiBackgroundJob::InvalidConfig, msg.(0))
+      expect { config.redis_pool_size = 0 }.to raise_error(MultiBackgroundJob::InvalidConfig, msg.(0))
+      expect { config.redis_pool_size = -1 }.to raise_error(MultiBackgroundJob::InvalidConfig, msg.(-1))
+    end
+  end
+
+  describe '.redis_pool_timeout=' do
+    it 'converts value to interger' do
+      config.redis_pool_timeout = '10'
+      expect(config.redis_pool_timeout).to eq(10)
+    end
+
+    it 'does not allow lower than zero' do
+      msg = -> (v) { "The #{v.inspect} for redis_pool_timeout is not valid. It must be greater than zero" }
+      expect { config.redis_pool_timeout = '0' }.to raise_error(MultiBackgroundJob::InvalidConfig, msg.(0))
+      expect { config.redis_pool_timeout = 0 }.to raise_error(MultiBackgroundJob::InvalidConfig, msg.(0))
+      expect { config.redis_pool_timeout = -1 }.to raise_error(MultiBackgroundJob::InvalidConfig, msg.(-1))
+    end
+  end
+
+  describe '.redis_namespace=' do
+    specify do
+      expect(config.redis_namespace).to eq('multi-bg')
+      config.redis_namespace = 'custom-ns'
+      expect(config.redis_namespace).to eq('custom-ns')
+    end
+  end
+
+  describe '.redis_config=' do
+    specify do
+      expect(config.redis_config).to eq({})
+      config.redis_config = 'redis://mymaster'
+      expect(config.redis_config).to eq(url: 'redis://mymaster')
+    end
+
+    specify do
+      expect(config.redis_config).to eq({})
+      config.redis_config = { path: '/tmp/redis.sock' }
+      expect(config.redis_config).to eq(path: '/tmp/redis.sock')
+    end
+  end
+
+  describe '.workers' do
+    specify do
+      expect(config.workers).to eq({})
+      config.workers = {
+        'DummyWorker' => {}
+      }
+      expect(config.workers).to eq('DummyWorker' => {})
+    end
+
+    it 'symbolize worker options' do
+      config.workers = {
+        DummyWorker: { 'queue' => 'default' }
+      }
+      expect(config.workers).to eq('DummyWorker' => { queue: 'default' })
+    end
+  end
+
+  describe '.worker_options' do
+    before do
+      config.workers = {
+        'DummyWorker' => { 'queue' => 'mailing' }
+      }
+    end
+
+    after { reset_config! }
+
+    it 'returns an empty hash as default' do
+      config.strict = false
+      expect(config.worker_options('MissingWorker')).to eq({})
+    end
+
+    it 'retrieves the options from workers using class_name' do
+      config.strict = true
+      expect(config.worker_options('DummyWorker')).to eq(queue: 'mailing')
+    end
+
+    it 'raises NotDefinedWorker when on strict mode' do
+      config.strict = true
+
+      expect { config.worker_options('MissingWorker') }.to raise_error(MultiBackgroundJob::NotDefinedWorker)
+    end
+  end
+
+  describe '.redis_pool' do
+    specify do
+      expect(config.redis_pool).to eq(timeout: 5, size: 5)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,4 +25,8 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.include Hooks::Timecop
+
+  def reset_config!
+    MultiBackgroundJob.instance_variable_set(:@config, nil)
+  end
 end


### PR DESCRIPTION
This PR adds the `Config` module to this project. This make the whole project configurable. Below are the list of configurations available:

* **redis_pool_size** Default to 5
* **redis_pool_timeout** Default to 5
* **redis_namespace** Default to "multi-bg"
* **redis_config** List of configurations to be passed along [redis-rb](https://github.com/redis/redis-rb);;
* **config_path** The YAML file to load configs. Default to(config/background_job.yml)
* **workers** List of worker classes with its initialization configs
* **strict** strict checking for known list of workers

## Workers config
Here is an example of a valid list of workers in YAML format:

```yaml
      "Accounts::ConfirmationEmailWorker":
        retry: false
        queue: "mailer"
      "Elastic::BatchIndex":
        retry: 5
        queue: "elasticsearch"
        adapter: "faktory"
```

