### PR TITLE
Sidekiq Worker 

### DIFF
--- a/lib/multi-background-job.rb
+++ b/lib/multi-background-job.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative './multi_background_job'

--- a/lib/multi_background_job.rb
+++ b/lib/multi_background_job.rb
@@ -1,10 +1,72 @@
 # frozen_string_literal: true
 
+require 'yaml'
+require 'securerandom'
+require 'multi_json'
+
 require_relative './multi_background_job/version'
 require_relative 'multi_background_job/errors'
 require_relative 'multi_background_job/config'
+require_relative 'multi_background_job/worker'
+require_relative 'multi_background_job/adapters/adapter'
+require_relative 'multi_background_job/adapters/sidekiq'
+require_relative 'multi_background_job/adapters/faktory'
 
+# This is a central point of our background job queue system.
+# We have more external services like API and Lme that queue jobs for pipeline processing.
+# So that way all services can share the same codebase and avoid incompatibility issues
+#
+# Example:
+#
+# Standard job.
+#   MultiBackgroundJob['UserWorker', queue: 'default']
+#     .with_args(1)
+#     .push(to: :sidekiq)
+#
+# Schedule the time when a job will be executed.
+#   MultiBackgroundJob['UserWorker']
+#     .with_args(1)
+#     .at(timestamp)
+#     .push(to: :sidekiq)
+#   MultiBackgroundJob['UserWorker']
+#     .with_args(1)
+#     .in(10.minutes)
+#     .push(to: :sidekiq)
+#
+# Unique jobs.
+#   MultiBackgroundJob['UserWorker', uniq: { across: :queue, timeout: 1.minute, unlock_policy: :start }]
+#     .with_args(1)
+#     .push(to: :sidekiq)
 module MultiBackgroundJob
+  SERVICES = {
+    sidekiq: Adapters::Sidekiq,
+    faktory: Adapters::Faktory,
+  }
+
+  # @param worker_class [String] The worker class name
+  # @param options [Hash] Options that will be passed along to the worker instance
+  # @return [MultiBackgroundJob::Worker] An instance of worker
+  def self.[](worker_class, **options)
+    Worker.new(worker_class, **config.worker_options(worker_class).merge(options))
+  end
+
+  def self.jid
+    SecureRandom.hex(12)
+  end
+
+  def self.for(service, **options)
+    require_relative "./workers/#{service}"
+
+    worker_options = options.merge(service: service)
+    mod = Workers.const_get(service.to_s.classify)
+    mod.module_eval do
+      define_method(:bg_worker_options) do
+        worker_options
+      end
+    end
+    mod
+  end
+
   def self.config
     @config ||= Config.new
   end

--- a/lib/multi_background_job/adapters/adapter.rb
+++ b/lib/multi_background_job/adapters/adapter.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module MultiBackgroundJob
+  module Adapters
+    class Adapter
+      # Push the worker job to the service
+      # @param _worker [MultiBackgroundJob::Worker] An instance of background worker
+      # @abstract Child classes should override this method
+      def self.push(_worker)
+        raise NotImplemented
+      end
+
+      # Sends the act state to the service
+      # @param _worker [MultiBackgroundJob::Worker] An instance of background worker
+      # @abstract Child classes should override this method
+      def self.acknowledge(_worker)
+        raise NotImplemented
+      end
+
+      # Coerces the raw payload into an instance of Worker
+      # @param payload [Object] the object that should be coerced to a Worker
+      # @options options [Hash] list of options that will be passed along to the Worker instance
+      # @return [MultiBackgroundJob::Worker] and instance of MultiBackgroundJob::Worker
+      # @abstract Child classes should override this method
+      def self.coerce_to_worker(payload, **options)
+        raise NotImplemented
+      end
+    end
+  end
+end

--- a/lib/multi_background_job/adapters/faktory.rb
+++ b/lib/multi_background_job/adapters/faktory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module MultiBackgroundJob
+  module Adapters
+    class Faktory < Adapter
+    end
+  end
+end

--- a/lib/multi_background_job/adapters/sidekiq.rb
+++ b/lib/multi_background_job/adapters/sidekiq.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+module MultiBackgroundJob
+  module Adapters
+    # This is a Sidekiq adapter that converts MultiBackgroundJob::Worker object into a sidekiq readable format
+    # and then push the jobs into the service.
+    class Sidekiq < Adapter
+      attr_reader :worker, :queue
+
+      def initialize(worker)
+        @worker = worker
+        @queue = worker.options.fetch(:queue, 'default')
+
+        @payload = {
+          'class' => worker.worker_class,
+          'args'  => worker.job.fetch('args', []),
+          'jid'   => worker.job.fetch('jid'),
+          'retry' => worker.options.fetch(:retry, true),
+          'queue' => @queue,
+          'created_at' => worker.job.fetch('created_at', Time.now.to_f),
+        }
+      end
+
+      # Coerces the raw payload into an instance of Worker
+      # @param payload [Hash] The job as json from redis
+      # @options options [Hash] list of options that will be passed along to the Worker instance
+      # @return [MultiBackgroundJob::Worker] and instance of MultiBackgroundJob::Worker
+      def self.coerce_to_worker(payload, **options)
+        raise(Error, 'invalid payload') unless payload.is_a?(Hash)
+        raise(Error, 'invalid payload') unless payload['class'].is_a?(String)
+
+        options[:retry] ||= payload['retry'] if payload.key?('retry')
+        options[:queue] ||= payload['queue'] if payload.key?('queue')
+        if (uniq_val = payload['uniq']).is_a?(Hash)
+          options[:uniq] ||= {}
+          options[:uniq][:across] ||= uniq_val['across']&.to_sym
+          options[:uniq][:timeout] ||= uniq_val['timeout']
+          options[:uniq][:unlock_policy] ||= uniq_val['unlock_policy']&.to_sym
+        end
+
+        MultiBackgroundJob[payload['class'], **options].tap do |worker|
+          worker.with_args(*Array(payload['args'])) if payload.key?('args')
+          worker.with_job_jid(payload['jid']) if payload.key?('jid')
+          worker.created_at(payload['created_at']) if payload.key?('created_at')
+          worker.enqueued_at(payload['enqueued_at']) if payload.key?('enqueued_at')
+          worker.at(payload['at']) if payload.key?('at')
+        end
+      end
+
+      # Initializes adapter and push job into the sidekiq service
+      #
+      # @param worker [MultiBackgroundJob::Worker] An instance of MultiBackgroundJob::Worker
+      # @return [Hash] Job payload
+      # @see push method for more details
+      def self.push(worker)
+        new(worker).push
+      end
+
+      # Initializes adapter and removes the uniq locking from redis
+      #
+      # @param worker [MultiBackgroundJob::Worker] An instance of MultiBackgroundJob::Worker
+      # @return [Boolean] True or
+      # @see push method for more details
+      def self.acknowledge(worker)
+        new(worker).acknowledge
+      end
+
+      # Push sidekiq to the Sidekiq(Redis actually).
+      #   * if job has the 'uniq' key. Then check if already exist
+      #   * If job has the 'at' key. Then schedule it
+      #   * Otherwise enqueue for immediate execution
+      #
+      # @return [Hash, NilClass] Payload that was sent to redis, or nil if job should be uniq and already exists
+      def push
+        return if duplicate?
+
+        @payload['enqueued_at'] = Time.now.to_f
+        if (timestamp = worker.job['at'])
+          MultiBackgroundJob.redis_pool.with do |redis|
+            redis.zadd(scheduled_queue_name, timestamp.to_f.to_s, to_json(@payload))
+          end
+        else
+          MultiBackgroundJob.redis_pool.with do |redis|
+            redis.lpush(immediate_queue_name, to_json(@payload))
+          end
+        end
+        @payload
+      end
+
+      # Removes the uniqueness locking from redis
+      #
+      # @return [Boolean, NilClass] Returns the redis response for the ZREM comand, or nil when
+      #   worker does not implement the uniqueness rule
+      def acknowledge
+        return unless uniqueness?
+
+        MultiBackgroundJob.redis_pool.with do |redis|
+          redis.zrem(uniqueness_queue_name, job_lock_id)
+        end
+      end
+
+      def flush_expired_members_of_uniqueness_queue
+        MultiBackgroundJob.redis_pool.with do |redis|
+          redis.zremrangebyscore(uniqueness_queue_name, '-inf', "(#{now}")
+        end
+      end
+
+      protected
+
+      def namespace
+        MultiBackgroundJob.config.redis_namespace
+      end
+
+      def uniqueness?
+        !!worker.options[:uniq]
+      end
+
+      def scheduled_queue_name
+        "#{namespace}:schedule"
+      end
+
+      def immediate_queue_name
+        "#{namespace}:queue:#{queue}"
+      end
+
+      def uniqueness_queue_name
+        across = worker.options.dig(:uniq, :across)
+        case across
+        when :systemwide
+          "#{namespace}:uniqueness"
+        when :queue
+          "#{namespace}:uniqueness:#{queue}"
+        else
+          raise Error, format(
+            '%<adapter>s can not resolve the uniqueness_queue_name using across %<across>p',
+            adapter: self.class.name,
+            across: across,
+          )
+        end
+      end
+
+      # This method uses an external queue to control duplications. It has no sidekiq connection.
+      # We are using Worker Class and its Arguments to generate a hexdigest as a locking key. And
+      # before enqueue new jobs we check if we have a "lock" active. The TTL of a lock is 1 week. Just
+      # to ensure locks won't last forever. When the job is executed this lock is removed allowing for an
+      # equal job to be queued again.
+      # @return [Boolean] True or False if already exist a lock for this job.
+      def duplicate?
+        return false unless uniqueness?
+
+        lock_ttl = now + worker.options.dig(:uniq, :timeout)
+
+        is_dup = false
+        MultiBackgroundJob.redis_pool.with do |redis|
+          timestamp = redis.zscore(uniqueness_queue_name, job_lock_id)
+          # binding.pry
+          if timestamp.nil? || (timestamp && timestamp < now) # It's not locked or lock already expired
+            @payload['uniq'] = worker.options.fetch(:uniq).each_with_object({}) do |(key, val), memo|
+              memo[key.to_s] = val.is_a?(Symbol) ? val.to_s : val
+            end
+            @payload['uniq']['ttl'] = lock_ttl
+            redis.zadd(uniqueness_queue_name, lock_ttl, job_lock_id)
+          else
+            is_dup = true
+          end
+          # Flush expired jobs
+          redis.zremrangebyscore(uniqueness_queue_name, '-inf', "(#{now}")
+        end
+
+        is_dup
+      end
+
+      # Generage a uniq hexdigest using job class name and args
+      def job_lock_id
+        @job_lock_id ||= Digest::SHA256.hexdigest to_json(@payload.values_at('class', 'args'))
+      end
+
+      def now
+        Time.now.to_f
+      end
+
+      def to_json(value)
+        MultiJson.dump(value, mode: :compat)
+      end
+    end
+  end
+end

--- a/lib/multi_background_job/errors.rb
+++ b/lib/multi_background_job/errors.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module MultiBackgroundJob
+  class Error < StandardError
+  end
+
+  class InvalidConfig < Error
+  end
+
+  class NotDefinedWorker < Error
+    def initialize(worker_class)
+      @worker_class = worker_class
+    end
+
+    def message
+      format(
+        "The %<worker>p is not defined and the MultiBackgroundJob is configured to work on strict mode.\n" +
+        "it's highly recommended to include this worker class to the list of known workers.\n" +
+        "Example: `MultiBackgroundJob.configure { |config| config.workers => { %<worker>p => {} } }`\n" +
+        'Another option is to set config.strict = false',
+        worker: @worker_class,
+      )
+    end
+  end
+end

--- a/lib/multi_background_job/worker.rb
+++ b/lib/multi_background_job/worker.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+module MultiBackgroundJob
+  class Worker
+    attr_reader :options, :job, :worker_class
+
+    UNIQ_ARGS = {
+      across: %i[queue systemwide],
+      timeout: 604800, # 1 week
+      unlock_policy: %i[success start],
+    }.freeze
+
+    def initialize(worker_class, **options)
+      @worker_class = worker_class
+      @options = options
+      @job = {}
+      if @options.key?(:uniq)
+        value = @options.delete(:uniq)
+        value = {} if value == true
+        setup_uniq_option(**value) if value.is_a?(Hash)
+      end
+    end
+
+    def self.coerce(service:, payload:, **opts)
+      SERVICES.fetch(service).coerce_to_worker(payload, **opts)
+    end
+
+    %i[created_at enqueued_at].each do |method_name|
+      define_method method_name do |value|
+        @job[method_name.to_s] = value
+
+        self
+      end
+    end
+
+    # Adds arguments to the job
+    # @return self
+    def with_args(*args)
+      @job['args'] = args
+
+      self
+    end
+
+    # Schedule the time when a job will be executed. Jobs which are scheduled in the past are enqueued for immediate execution.
+    # @param timestamp [Number] timestamp, numeric or something that acts numeric.
+    # @return self
+    def in(timestamp)
+      now = Time.now.to_f
+      int = timestamp.respond_to?(:strftime) ? timestamp.to_f : now + timestamp.to_f
+      return self if int <= now
+
+      @job['at'] = int
+      @job['created_at'] = now
+
+      self
+    end
+    alias_method :at, :in
+
+    def with_job_jid(jid = nil)
+      @job['jid'] ||= jid || MultiBackgroundJob.jid
+
+      self
+    end
+
+    # @param :to [Symbol] Adapter key
+    # @return Response of service
+    # @see MultiBackgroundJob::Adapters::** for more details
+    def push(to: nil)
+      to ||= options[:service]
+      unless SERVICES.include?(to)
+        raise Error, format('Service %<to>p is not implemented. Please use one of %<list>p', to: to, list: SERVICES.keys)
+      end
+
+      @job['created_at'] ||= Time.now.to_f
+      SERVICES[to].push(with_job_jid)
+    end
+
+    # @param :to [Symbol] Adapter key
+    # @return Response of service
+    # @see MultiBackgroundJob::Adapters::** for more details
+    def acknowledge(to: nil)
+      to ||= options[:service]
+      unless SERVICES.include?(to)
+        raise Error, format('Service %<to>p is not implemented. Please use one of %<list>p', to: to, list: SERVICES.keys)
+      end
+
+      SERVICES[to].acknowledge(self)
+    end
+
+    def eql?(other)
+      worker_class == other.worker_class && job == other.job && options == other.options
+    end
+    alias == eql?
+
+    protected
+
+    # @options [Hash] Uniq definitions
+    # @option [Symbol] :across Valid options are :queue and :systemwide. If jobs should not to be duplicated on
+    #   current queue or the entire system
+    # @option [Integer] :timeout Amount of times in seconds. Timeout decides how long to wait for acquiring the lock.
+    #   A default timeout is defined to 1 week so unique locks won't last forever.
+    # @option [Symbol] :unlock_policy Control when the unique lock is removed. The default value is `success`.
+    #   The job will not unlock until it executes successfully, it will remain locked even if it raises an error and
+    #   goes into the retry queue. The alternative value is `start` the job will unlock right before it starts executing
+    # @return self
+    def setup_uniq_option(across: :queue, timeout: nil, unlock_policy: :success)
+      unless UNIQ_ARGS[:across].include?(across.to_sym)
+        raise Error, format('Invalid `across: %<given>p` option. Only %<expected>p are allowed.', given: across, expected: UNIQ_ARGS[:across])
+      end
+      unless UNIQ_ARGS[:unlock_policy].include?(unlock_policy.to_sym)
+        raise Error, format('Invalid `unlock_policy: %<given>p` option. Only %<expected>p are allowed.', given: unlock_policy, expected: UNIQ_ARGS[:unlock_policy])
+      end
+      timeout = UNIQ_ARGS[:timeout] if timeout.to_i <= 0
+
+      @options[:uniq] = {
+        across: across.to_sym,
+        timeout: timeout.to_i,
+        unlock_policy: unlock_policy.to_sym,
+      }
+    end
+  end
+end

--- a/spec/multi_background_job/adapters/sidekiq_spec.rb
+++ b/spec/multi_background_job/adapters/sidekiq_spec.rb
@@ -1,0 +1,547 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe MultiBackgroundJob::Adapters::Sidekiq do
+  let(:worker_class) { 'DummyWorker' }
+  let(:worker_args) { ['User', 1] }
+  let(:worker_opts) { {} }
+  let(:worker_job_id) { '123xyz' }
+  let(:worker) do
+    MultiBackgroundJob::Worker
+      .new(worker_class, **worker_opts)
+      .with_job_jid(worker_job_id)
+      .with_args(*worker_args)
+  end
+  let(:model) { described_class.new(worker) }
+  let(:redis_dataset) do
+    {
+      standard_name: model.send(:immediate_queue_name),
+      scheduled_name: model.send(:scheduled_queue_name),
+    }.tap do |h|
+      h[:uniqueness_name] = model.send(:uniqueness_queue_name) if worker.options.key?(:uniq)
+    end
+  end
+
+  before do
+    MultiBackgroundJob.configure { |c| c.workers = { 'DummyWorker' => {} } }
+  end
+
+  after do
+    reset_config!
+  end
+
+  describe '.push class method' do
+    specify do
+      expect(described_class).to receive(:new).with(worker).and_return(double(push: 'ok'))
+      expect(described_class.push(worker)).to eq('ok')
+    end
+  end
+
+  describe '.acknowledge class method' do
+    specify do
+      expect(described_class).to receive(:new).with(worker).and_return(double(acknowledge: 'ok'))
+      expect(described_class.acknowledge(worker)).to eq('ok')
+    end
+  end
+
+  describe '.acknowledge instance method', freeze_at: [2020, 7, 2, 12, 30, 50] do
+    subject(:ack!) { model.acknowledge }
+
+    let(:now) { Time.now.to_f }
+
+    context 'with a standard job' do
+      it { expect(model.send(:uniqueness?)).to eq(false) }
+
+      it 'does dothing' do
+        expect(MultiBackgroundJob.redis_pool).not_to receive(:with)
+
+        is_expected.to eq(nil)
+      end
+    end
+
+    context 'with a unique job across queue' do
+      let(:worker_opts) do
+        {
+          queue: 'mailer',
+          uniq: { across: :queue },
+        }
+      end
+
+      def locks_count(conn)
+        conn.zcount(redis_dataset[:uniqueness_name], 0, now + (MINUTE_IN_SECONDS * 2))
+      end
+
+      def clear_locks(conn)
+        conn.del(redis_dataset[:uniqueness_name])
+      end
+
+      it { expect(model.send(:uniqueness?)).to eq(true) }
+
+      specify do
+        expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness:mailer$/)
+      end
+
+      it 'does nothing when set does not exist' do
+        redis do |conn|
+          clear_locks(conn)
+          expect(ack!).to eq(false)
+          expect(locks_count(conn)).to eq(0)
+        end
+      end
+
+      it 'removes expired lock that matches job identity' do
+        redis do |conn|
+          clear_locks(conn)
+          [model.send(:job_lock_id), 'xxx'].each do |lock_id|
+            conn.zadd(redis_dataset[:uniqueness_name], now-10, lock_id)
+          end
+          result = nil
+          expect {
+            result = ack!
+          }.to change { locks_count(conn) }.from(2).to(1)
+          expect(result).to eq(true)
+        end
+      end
+
+      it 'removes active lock that matches job identity' do
+        redis do |conn|
+          clear_locks(conn)
+          [model.send(:job_lock_id), 'xxx'].each do |lock_id|
+            conn.zadd(redis_dataset[:uniqueness_name], now+10, lock_id)
+          end
+          result = nil
+          expect {
+            result = ack!
+          }.to change { locks_count(conn) }.from(2).to(1)
+          expect(result).to eq(true)
+        end
+      end
+    end
+
+    context 'with a unique job across system' do
+      let(:worker_opts) do
+        {
+          queue: 'mailer',
+          uniq: { across: :systemwide },
+        }
+      end
+
+      def locks_count(conn)
+        conn.zcount(redis_dataset[:uniqueness_name], 0, now + (MINUTE_IN_SECONDS * 4))
+      end
+
+      def clear_locks(conn)
+        conn.del(redis_dataset[:uniqueness_name])
+      end
+
+      it { expect(model.send(:uniqueness?)).to eq(true) }
+
+      specify do
+        expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness$/)
+      end
+
+      it 'does nothing when set does not exist' do
+        redis do |conn|
+          clear_locks(conn)
+          expect(ack!).to eq(false)
+          expect(locks_count(conn)).to eq(0)
+        end
+      end
+
+      it 'removes expired lock that matches job identity' do
+        redis do |conn|
+          clear_locks(conn)
+          [model.send(:job_lock_id), 'xxx'].each do |lock_id|
+            conn.zadd(redis_dataset[:uniqueness_name], now-10, lock_id)
+          end
+          result = nil
+          expect {
+            result = ack!
+          }.to change { locks_count(conn) }.from(2).to(1)
+          expect(result).to eq(true)
+        end
+      end
+
+      it 'removes active lock that matches job identity' do
+        redis do |conn|
+          clear_locks(conn)
+          [model.send(:job_lock_id), 'xxx'].each do |lock_id|
+            conn.zadd(redis_dataset[:uniqueness_name], now+10, lock_id)
+          end
+          result = nil
+          expect {
+            result = ack!
+          }.to change { locks_count(conn) }.from(2).to(1)
+          expect(result).to eq(true)
+        end
+      end
+    end
+  end
+
+  describe '.push instance method', freeze_at: [2020, 7, 2, 12, 30, 50] do
+    subject(:push!) { model.push }
+
+    let(:now) { Time.now.to_f }
+
+    context 'with a standard job' do
+      it 'adds a valid sidekiq hash to redis' do
+        redis do |conn|
+          conn.del(redis_dataset[:standard_name])
+          conn.del(redis_dataset[:scheduled_name])
+          expect(conn.llen(redis_dataset[:standard_name])).to eq(0)
+          expect(conn.zcount(redis_dataset[:scheduled_name], 0, now + DAY_IN_SECONDS)).to eq(0)
+
+          result = push!
+          expect(result).to eq(
+            'args' => worker_args,
+            'class' => worker_class,
+            'jid' => worker_job_id,
+            'created_at' => Time.now.to_f,
+            'enqueued_at' => Time.now.to_f,
+            'queue' => 'default',
+            'retry' => true,
+          )
+          expect(conn.llen(redis_dataset[:standard_name])).to eq(1)
+          expect(conn.zcount(redis_dataset[:scheduled_name], 0, now + DAY_IN_SECONDS)).to eq(0)
+
+          raw_payload = conn.lpop(redis_dataset[:standard_name])
+          expect(MultiJson.dump(result, mode: :compat)).to eq(raw_payload)
+        end
+      end
+    end
+
+    context 'with a scheduled job' do
+      let(:worker_opts) { { queue: 'mailer' } }
+
+      before do
+        worker.at(Time.now + HOUR_IN_SECONDS)
+      end
+
+      it 'adds a valid sidekiq hash to redis' do
+        redis do |conn|
+          conn.del(redis_dataset[:standard_name])
+          conn.del(redis_dataset[:scheduled_name])
+          expect(conn.llen(redis_dataset[:standard_name])).to eq(0)
+          expect(conn.zcount(redis_dataset[:scheduled_name], 0, now + DAY_IN_SECONDS)).to eq(0)
+
+          result = push!
+          expect(result).to eq(
+            'args' => worker_args,
+            'class' => worker_class,
+            'jid' => worker_job_id,
+            'created_at' => Time.now.to_f,
+            'enqueued_at' => Time.now.to_f,
+            'queue' => 'mailer',
+            'retry' => true,
+          )
+          expect(conn.llen(redis_dataset[:standard_name])).to eq(0)
+          expect(conn.zcount(redis_dataset[:scheduled_name], 0, now + DAY_IN_SECONDS)).to eq(1)
+
+          raw_payload = conn.zrangebyscore(redis_dataset[:scheduled_name], now, '+inf')[0]
+          expect(MultiJson.dump(result, mode: :compat)).to eq(raw_payload)
+        end
+      end
+    end
+
+    context 'with a unique job across queue' do
+      let(:worker_opts) do
+        {
+          queue: 'mailer',
+          uniq: { across: :queue, timeout: HOUR_IN_SECONDS },
+        }
+      end
+
+      specify do
+        expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness:mailer$/)
+      end
+
+      it 'adds a lock with 1 hour of TTL and enqueues a new job' do
+        redis do |conn|
+          conn.del(redis_dataset[:standard_name])
+          conn.del(redis_dataset[:scheduled_name])
+          conn.del(redis_dataset[:uniqueness_name])
+          expect(conn.llen(redis_dataset[:standard_name])).to eq(0)
+          expect(conn.zcount(redis_dataset[:scheduled_name], 0, now + DAY_IN_SECONDS)).to eq(0)
+          expect(conn.zcount(redis_dataset[:uniqueness_name], 0, now + DAY_IN_SECONDS)).to eq(0)
+
+          result = push!
+          expect(result).to eq(
+            'args' => worker_args,
+            'class' => worker_class,
+            'jid' => worker_job_id,
+            'created_at' => Time.now.to_f,
+            'enqueued_at' => Time.now.to_f,
+            'queue' => 'mailer',
+            'retry' => true,
+            'uniq' => {
+              'across' => 'queue',
+              'timeout' => 3_600,
+              'unlock_policy' => 'success',
+              'ttl' => now + 3_600,
+            }
+          )
+          expect(conn.llen(redis_dataset[:standard_name])).to eq(1)
+          expect(conn.zcount(redis_dataset[:scheduled_name], 0, now + DAY_IN_SECONDS)).to eq(0)
+          expect(conn.zcount(redis_dataset[:uniqueness_name], 0, now + DAY_IN_SECONDS)).to eq(1)
+
+          lock_id = conn.zrangebyscore(redis_dataset[:uniqueness_name], now + 3_600, now + 3_600)[0]
+          expect(lock_id).to be_a_kind_of(String)
+
+          # Adds more expired jobs to be flushed
+          conn.zadd(redis_dataset[:uniqueness_name], now-2, '123')
+          conn.zadd(redis_dataset[:uniqueness_name], now-1, '456')
+          travel_to = Time.now + HOUR_IN_SECONDS + 1
+          Timecop.travel(travel_to) do
+            new_result = model.push
+            expect(conn.llen(redis_dataset[:standard_name])).to eq(2)
+            expect(conn.zcount(redis_dataset[:uniqueness_name], 0, now + DAY_IN_SECONDS)).to eq(1)
+            ttl = conn.zscore(redis_dataset[:uniqueness_name], lock_id)
+            expect(ttl.to_i).to eq(travel_to.to_i + 3_600)
+          end
+        end
+      end
+    end
+
+    context 'with a unique job across system' do
+      let(:worker_opts) do
+        {
+          queue: 'mailer',
+          uniq: { across: :systemwide, timeout: HOUR_IN_SECONDS },
+        }
+      end
+
+      specify do
+        expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness$/)
+      end
+
+      it 'does not push job when active uniqueness lock exist' do
+        redis do |conn|
+          conn.del(redis_dataset[:standard_name])
+          conn.del(redis_dataset[:scheduled_name])
+          conn.del(redis_dataset[:uniqueness_name])
+          expect(conn.llen(redis_dataset[:standard_name])).to eq(0)
+          expect(conn.zcount(redis_dataset[:scheduled_name], 0, now + DAY_IN_SECONDS)).to eq(0)
+          expect(conn.zcount(redis_dataset[:uniqueness_name], 0, now + DAY_IN_SECONDS)).to eq(0)
+
+          # Adds a lock_id
+          lock_id = Digest::SHA256.hexdigest model.send(:to_json, [worker_class, worker_args])
+          conn.zadd(redis_dataset[:uniqueness_name], now+1, lock_id)
+          conn.zadd(redis_dataset[:uniqueness_name], now-2, '123')
+          conn.zadd(redis_dataset[:uniqueness_name], now-1, '456')
+          expect(conn.zcount(redis_dataset[:uniqueness_name], 0, now + DAY_IN_SECONDS)).to eq(3)
+
+          result = push!
+          expect(result).to eq(nil)
+          expect(conn.zcount(redis_dataset[:uniqueness_name], 0, now + DAY_IN_SECONDS)).to eq(1)
+          ttl = conn.zscore(redis_dataset[:uniqueness_name], lock_id)
+          expect(ttl.to_i).to eq(now.to_i+1)
+        end
+      end
+
+      it 'adds a lock with 1 hour of TTL and enqueues a new job' do
+        redis do |conn|
+          conn.del(redis_dataset[:standard_name])
+          conn.del(redis_dataset[:scheduled_name])
+          conn.del(redis_dataset[:uniqueness_name])
+          expect(conn.llen(redis_dataset[:standard_name])).to eq(0)
+          expect(conn.zcount(redis_dataset[:scheduled_name], 0, now + DAY_IN_SECONDS)).to eq(0)
+          expect(conn.zcount(redis_dataset[:uniqueness_name], 0, now + DAY_IN_SECONDS)).to eq(0)
+
+          result = push!
+          expect(result).to eq(
+            'args' => worker_args,
+            'class' => worker_class,
+            'jid' => worker_job_id,
+            'created_at' => Time.now.to_f,
+            'enqueued_at' => Time.now.to_f,
+            'queue' => 'mailer',
+            'retry' => true,
+            'uniq' => {
+              'across' => 'systemwide',
+              'timeout' => 3_600,
+              'unlock_policy' => 'success',
+              'ttl' => now + 3_600,
+            }
+          )
+          expect(conn.llen(redis_dataset[:standard_name])).to eq(1)
+          expect(conn.zcount(redis_dataset[:scheduled_name], 0, now + DAY_IN_SECONDS)).to eq(0)
+          expect(conn.zcount(redis_dataset[:uniqueness_name], 0, now + DAY_IN_SECONDS)).to eq(1)
+
+          lock_id = conn.zrangebyscore(redis_dataset[:uniqueness_name], now + 3_600, now + 3_600)[0]
+          expect(lock_id).to be_a_kind_of(String)
+
+          # Adds more expired jobs to be flushed
+          conn.zadd(redis_dataset[:uniqueness_name], now-2, '123')
+          conn.zadd(redis_dataset[:uniqueness_name], now-1, '456')
+          travel_to = Time.now + HOUR_IN_SECONDS + 1
+          Timecop.travel(travel_to) do
+            new_result = model.push
+            expect(conn.llen(redis_dataset[:standard_name])).to eq(2)
+            expect(conn.zcount(redis_dataset[:uniqueness_name], 0, now + DAY_IN_SECONDS)).to eq(1)
+            ttl = conn.zscore(redis_dataset[:uniqueness_name], lock_id)
+            expect(ttl.to_i).to eq(travel_to.to_i + 3_600)
+          end
+        end
+      end
+    end
+  end
+
+  describe '.coerce_to_worker class method', freeze_at: [2020, 7, 2, 12, 30, 50] do
+    specify do
+      expect { described_class.coerce_to_worker(nil) }.to raise_error(MultiBackgroundJob::Error, 'invalid payload')
+      expect { described_class.coerce_to_worker('test') }.to raise_error(MultiBackgroundJob::Error, 'invalid payload')
+      expect { described_class.coerce_to_worker({}) }.to raise_error(MultiBackgroundJob::Error, 'invalid payload')
+    end
+
+    specify do
+      expected = MultiBackgroundJob::Worker.new('DummyWorker')
+      not_expected = MultiBackgroundJob::Worker.new('OtherWorker')
+      actual = described_class.coerce_to_worker(
+        {
+          'class' => 'DummyWorker',
+        },
+      )
+      expect(actual).to eq(expected)
+      expect(actual).not_to eq(not_expected)
+    end
+
+    specify do
+      expected = MultiBackgroundJob::Worker.new('DummyWorker', retry: false)
+      not_expected = MultiBackgroundJob::Worker.new('DummyWorker', retry: true)
+      actual = described_class.coerce_to_worker(
+        {
+          'class' => 'DummyWorker',
+          'retry' => false,
+        },
+      )
+      expect(actual).to eq(expected)
+      expect(actual).not_to eq(not_expected)
+    end
+
+    specify do
+      expected = MultiBackgroundJob::Worker.new('DummyWorker', queue: 'foo')
+      not_expected = MultiBackgroundJob::Worker.new('DummyWorker', queue: 'bar')
+      actual = described_class.coerce_to_worker(
+        {
+          'class' => 'DummyWorker',
+          'queue' => 'foo',
+        },
+      )
+      expect(actual).to eq(expected)
+      expect(actual).not_to eq(not_expected)
+    end
+
+    specify do
+      expected = MultiBackgroundJob::Worker.new('DummyWorker', uniq: { across: :systemwide, timeout: HOUR_IN_SECONDS, unlock_policy: :start })
+      not_expected = MultiBackgroundJob::Worker.new('DummyWorker', uniq: { across: :queue, timeout: HOUR_IN_SECONDS, unlock_policy: :start })
+      actual = described_class.coerce_to_worker(
+        {
+          'class' => 'DummyWorker',
+          'uniq' => {
+            'across' => 'systemwide',
+            'timeout' => 3_600,
+            'unlock_policy' => 'start',
+            'ttl' => Time.now + 3_600,
+          },
+        },
+      )
+      expect(actual).to eq(expected)
+      expect(actual).not_to eq(not_expected)
+    end
+
+    specify do
+      expected = MultiBackgroundJob::Worker.new('DummyWorker').with_args(1)
+      not_expected = MultiBackgroundJob::Worker.new('DummyWorker').with_args([1, 2])
+      actual = described_class.coerce_to_worker(
+        {
+          'class' => 'DummyWorker',
+          'args' => [1],
+        },
+      )
+      expect(actual).to eq(expected)
+      expect(actual).not_to eq(not_expected)
+    end
+
+    specify do
+      expected = MultiBackgroundJob::Worker.new('DummyWorker').with_job_jid('123')
+      not_expected = MultiBackgroundJob::Worker.new('DummyWorker').with_job_jid('456')
+      actual = described_class.coerce_to_worker(
+        {
+          'class' => 'DummyWorker',
+          'jid' => '123',
+        },
+      )
+      expect(actual).to eq(expected)
+      expect(actual).not_to eq(not_expected)
+    end
+
+    specify do
+      expected = MultiBackgroundJob::Worker.new('DummyWorker').created_at((Time.now - (MINUTE_IN_SECONDS * 10)).to_f)
+      not_expected = MultiBackgroundJob::Worker.new('DummyWorker').created_at((Time.now - (MINUTE_IN_SECONDS * 11)).to_f)
+      actual = described_class.coerce_to_worker(
+        {
+          'class' => 'DummyWorker',
+          'created_at' => (Time.now - (MINUTE_IN_SECONDS * 10)).to_f,
+        },
+      )
+      expect(actual).to eq(expected)
+      expect(actual).not_to eq(not_expected)
+    end
+
+    specify do
+      expected = MultiBackgroundJob::Worker.new('DummyWorker').enqueued_at((Time.now - (MINUTE_IN_SECONDS * 10)).to_f)
+      not_expected = MultiBackgroundJob::Worker.new('DummyWorker').enqueued_at((Time.now - (MINUTE_IN_SECONDS * 11)).to_f)
+      actual = described_class.coerce_to_worker(
+        {
+          'class' => 'DummyWorker',
+          'enqueued_at' => (Time.now - (MINUTE_IN_SECONDS * 10)).to_f,
+        },
+      )
+      expect(actual).to eq(expected)
+      expect(actual).not_to eq(not_expected)
+    end
+
+    specify do
+      expected = MultiBackgroundJob::Worker.new('DummyWorker').at((Time.now + (MINUTE_IN_SECONDS * 10)).to_f)
+      not_expected = MultiBackgroundJob::Worker.new('DummyWorker').at((Time.now + (MINUTE_IN_SECONDS * 11)).to_f)
+      actual = described_class.coerce_to_worker(
+        {
+          'class' => 'DummyWorker',
+          'at' => (Time.now + (MINUTE_IN_SECONDS * 10)).to_f,
+          'created_at' => (Time.now + (MINUTE_IN_SECONDS * 10)).to_f,
+        },
+      )
+      expect(actual).to eq(expected)
+      expect(actual).not_to eq(not_expected)
+    end
+
+    specify do
+      expected = MultiBackgroundJob::Worker
+        .new('DummyWorker', queue: 'other', retry: true)
+        .with_args(123)
+        .with_job_jid('16c4c1ee56d858d1a5d0cacb')
+        .created_at(1589474236)
+        .enqueued_at(1589474236)
+
+      actual = described_class.coerce_to_worker(
+        {
+          'class' => 'DummyWorker',
+          'args'  => [123],
+          'retry' =>  true,
+          'queue' => 'other',
+          'jid'   => '16c4c1ee56d858d1a5d0cacb',
+          'created_at' => 1589474236.0,
+          'enqueued_at' => 1589474236.0,
+        },
+      )
+      expect(actual).to eq(expected)
+    end
+  end
+
+  def redis
+    MultiBackgroundJob.redis_pool.with do |conn|
+      yield conn
+    end
+  end
+end

--- a/spec/multi_background_job/errors_spec.rb
+++ b/spec/multi_background_job/errors_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'MultiBackgroundJob errors' do
+
+  describe 'MultiBackgroundJob::NotDefinedWorker' do
+    specify do
+      msg = <<~MSG.chomp
+      The "MissingWorker" is not defined and the MultiBackgroundJob is configured to work on strict mode.
+      it's highly recommended to include this worker class to the list of known workers.
+      Example: `MultiBackgroundJob.configure { |config| config.workers => { "MissingWorker" => {} } }`
+      Another option is to set config.strict = false
+      MSG
+
+      error = MultiBackgroundJob::NotDefinedWorker.new('MissingWorker')
+      expect(error.message).to eq(msg)
+    end
+  end
+end

--- a/spec/multi_background_job/worker_spec.rb
+++ b/spec/multi_background_job/worker_spec.rb
@@ -1,0 +1,364 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe MultiBackgroundJob::Worker do
+  let(:worker) { described_class.new('DummyWorker') }
+
+  describe '.options' do
+    specify do
+      expected_options = described_class.new('DummyWorker').options
+      expect(expected_options).to eq({})
+    end
+
+    specify do
+      expected_options = described_class.new('DummyWorker', retry: true).options
+      expect(expected_options).to eq(retry: true)
+    end
+  end
+
+  describe '.created_at', freeze_at: [2020, 7, 1, 22, 24, 40] do
+    let(:now) { Time.now }
+
+    specify do
+      expect(worker.job).to eq({})
+      expect(worker.created_at(now)).to eq(worker)
+      expect(worker.job).to eq('created_at' => now)
+    end
+  end
+
+  describe '.enqueued_at', freeze_at: [2020, 7, 1, 22, 24, 40] do
+    let(:now) { Time.now }
+
+    specify do
+      expect(worker.job).to eq({})
+      expect(worker.enqueued_at(now)).to eq(worker)
+      expect(worker.job).to eq('enqueued_at' => now)
+    end
+  end
+
+  describe '.with_args' do
+    specify do
+      expect(worker.job).to eq({})
+      expect(worker.with_args()).to eq(worker)
+      expect(worker.job).to eq('args' => [])
+    end
+
+    specify do
+      expect(worker.job).to eq({})
+      expect(worker.with_args(1)).to eq(worker)
+      expect(worker.job).to eq('args' => [1])
+    end
+
+    specify do
+      expect(worker.job).to eq({})
+      expect(worker.with_args(1, foo: :bar)).to eq(worker)
+      expect(worker.job).to eq('args' => [1, { foo: :bar }])
+    end
+  end
+
+  describe '.at', freeze_at: [2020, 7, 1, 22, 24, 40] do
+    let(:now) { Time.now }
+
+    specify do
+      expect(worker.job).to eq({})
+      expect(worker.at(10)).to eq(worker)
+      expect(worker.job).to eq('at' => now.to_f + 10, 'created_at' => now.to_f)
+    end
+
+    specify do
+      expect(worker.job).to eq({})
+      expect(worker.at(now + HOUR_IN_SECONDS)).to eq(worker)
+      expect(worker.job).to eq('at' => now.to_f + 3_600, 'created_at' => now.to_f)
+    end
+
+    specify do
+      expect(worker.job).to eq({})
+      expect(worker.at(0)).to eq(worker)
+      expect(worker.job).to eq({})
+      expect(worker.at(now - 1)).to eq(worker)
+      expect(worker.job).to eq({})
+    end
+  end
+
+  describe '.in', freeze_at: [2020, 7, 1, 22, 24, 40] do
+    let(:now) { Time.now }
+
+    specify do
+      expect(worker.job).to eq({})
+      expect(worker.in(10)).to eq(worker)
+      expect(worker.job).to eq('at' => now.to_f + 10, 'created_at' => now.to_f)
+    end
+
+    specify do
+      expect(worker.job).to eq({})
+      expect(worker.in(now + HOUR_IN_SECONDS)).to eq(worker)
+      expect(worker.job).to eq('at' => now.to_f + 3_600, 'created_at' => now.to_f)
+    end
+
+    specify do
+      expect(worker.job).to eq({})
+      expect(worker.in(0)).to eq(worker)
+      expect(worker.job).to eq({})
+      expect(worker.in(now - 1)).to eq(worker)
+      expect(worker.job).to eq({})
+    end
+  end
+
+  describe '.setup_uniq_option' do
+    let(:defaults) do
+      {
+        across: :queue,
+        timeout: WEEK_IN_SECONDS,
+        unlock_policy: :success,
+      }
+    end
+
+    specify do
+      worker = described_class.new('DummyWorker')
+      expect(worker.job).to eq({})
+      expect(worker.options).to eq({})
+    end
+
+    specify do
+      worker = described_class.new('DummyWorker', uniq: {})
+      expect(worker.job).to eq({})
+      expect(worker.options).to eq(
+        uniq: defaults
+      )
+    end
+
+    specify do
+      worker = described_class.new('DummyWorker', uniq: true)
+      expect(worker.job).to eq({})
+      expect(worker.options).to eq(
+        uniq: defaults
+      )
+    end
+
+    specify do
+      worker = described_class.new('DummyWorker', uniq: false)
+      expect(worker.job).to eq({})
+      expect(worker.options).to eq({})
+    end
+
+    context 'with custom :across option' do
+      specify do
+        expect { described_class.new('DummyWorker', uniq: { across: :invalid }) }.to raise_error(
+          MultiBackgroundJob::Error, 'Invalid `across: :invalid` option. Only [:queue, :systemwide] are allowed.'
+        )
+      end
+
+      specify do
+        worker = described_class.new('DummyWorker', uniq: { across: :queue })
+        expect(worker.options).to eq(uniq: defaults)
+        expect(worker.job).to eq({})
+      end
+
+      specify do
+        worker = described_class.new('DummyWorker', uniq: { across: :systemwide })
+        expect(worker.job).to eq({})
+        expect(worker.options).to eq(
+          uniq: defaults.merge(across: :systemwide),
+        )
+      end
+
+      specify do
+        worker = described_class.new('DummyWorker', uniq: { across: 'systemwide' })
+        expect(worker.job).to eq({})
+        expect(worker.options).to eq(
+          uniq: defaults.merge(across: :systemwide),
+        )
+      end
+    end
+
+    context 'with custom :unlock_policy option' do
+      specify do
+        expect { described_class.new('DummyWorker', uniq: { unlock_policy: :invalid }) }.to raise_error(
+          MultiBackgroundJob::Error, 'Invalid `unlock_policy: :invalid` option. Only [:success, :start] are allowed.'
+        )
+      end
+
+      specify do
+        worker = described_class.new('DummyWorker', uniq: { unlock_policy: :success })
+        expect(worker.job).to eq({})
+        expect(worker.options).to eq(uniq: defaults)
+      end
+
+      specify do
+        worker = described_class.new('DummyWorker', uniq: { unlock_policy: :start })
+        expect(worker.job).to eq({})
+        expect(worker.options).to eq(
+          uniq: defaults.merge(unlock_policy: :start)
+        )
+      end
+
+      specify do
+        worker = described_class.new('DummyWorker', uniq: { unlock_policy: 'start' })
+        expect(worker.job).to eq({})
+        expect(worker.options).to eq(
+          uniq: defaults.merge(unlock_policy: :start)
+        )
+      end
+    end
+
+    context 'with custom :timeout option' do
+      specify do
+        worker = described_class.new('DummyWorker', uniq: { timeout: -1 })
+        expect(worker.job).to eq({})
+        expect(worker.options).to eq(
+          uniq: defaults
+        )
+      end
+
+      specify do
+        worker = described_class.new('DummyWorker', uniq: { timeout: 10 })
+        expect(worker.job).to eq({})
+        expect(worker.options).to eq(
+          uniq: defaults.merge(timeout: 10)
+        )
+      end
+    end
+  end
+
+  describe '.push', freeze_at: [2020, 7, 1, 22, 24, 40] do
+    let(:now) { Time.now }
+
+    specify do
+      expect(worker.job).to eq({})
+      expect { worker.push(to: :invalid) }.to raise_error(
+        MultiBackgroundJob::Error, 'Service :invalid is not implemented. Please use one of [:sidekiq, :faktory]'
+      )
+      expect(worker.job).to eq({})
+    end
+
+    context 'with faktory service' do
+      specify do
+        expect(MultiBackgroundJob).to receive(:jid).and_return('123xyz')
+        expect(MultiBackgroundJob::Adapters::Faktory).to receive(:push).with(worker).and_return('ok')
+        expect(worker.push(to: :faktory)).to eq('ok')
+        expect(worker.job).to eq('jid' => '123xyz', 'created_at' => now.to_f)
+      end
+
+      specify do
+        worker = described_class.new('DummyWorker', service: :faktory)
+        expect(MultiBackgroundJob::Adapters::Faktory).to receive(:push).with(worker).and_return('ok')
+        expect(worker.push).to eq('ok')
+      end
+    end
+
+    context 'with sidekiq service' do
+      specify do
+        expect(MultiBackgroundJob).to receive(:jid).and_return('123xyz')
+        expect(MultiBackgroundJob::Adapters::Sidekiq).to receive(:push).with(worker).and_return('ok')
+        expect(worker.push(to: :sidekiq)).to eq('ok')
+        expect(worker.job).to eq('jid' => '123xyz', 'created_at' => now.to_f)
+      end
+
+      specify do
+        worker = described_class.new('DummyWorker', service: :sidekiq)
+        expect(MultiBackgroundJob::Adapters::Sidekiq).to receive(:push).with(worker).and_return('ok')
+        expect(worker.push).to eq('ok')
+      end
+    end
+  end
+
+  describe '.acknowledge' do
+    specify do
+      expect { worker.acknowledge(to: :invalid) }.to raise_error(
+        MultiBackgroundJob::Error, 'Service :invalid is not implemented. Please use one of [:sidekiq, :faktory]'
+      )
+      expect(worker.job).to eq({})
+    end
+
+    context 'with faktory service' do
+      specify do
+        expect(MultiBackgroundJob::Adapters::Faktory).to receive(:acknowledge).with(worker).and_return('ok')
+        expect(worker.acknowledge(to: :faktory)).to eq('ok')
+      end
+
+      specify do
+        worker = described_class.new('DummyWorker', service: :faktory)
+        expect(MultiBackgroundJob::Adapters::Faktory).to receive(:acknowledge).with(worker).and_return('ok')
+        expect(worker.acknowledge).to eq('ok')
+      end
+    end
+
+    context 'with sidekiq service' do
+      specify do
+        expect(MultiBackgroundJob::Adapters::Sidekiq).to receive(:acknowledge).with(worker).and_return('ok')
+        expect(worker.acknowledge(to: :sidekiq)).to eq('ok')
+      end
+
+      specify do
+        worker = described_class.new('DummyWorker', service: :sidekiq)
+        expect(MultiBackgroundJob::Adapters::Sidekiq).to receive(:acknowledge).with(worker).and_return('ok')
+        expect(worker.acknowledge).to eq('ok')
+      end
+    end
+  end
+
+  describe '.coerce class method' do
+    let(:options) { { queue: 'custom' } }
+    let(:payload) { { 'jid' => '123' } }
+    let(:worker) { double }
+
+    context 'with :faktory' do
+      specify do
+        expect(MultiBackgroundJob::Adapters::Faktory).to receive(:coerce_to_worker).with(payload, **options).and_return(worker)
+        expect(MultiBackgroundJob::Worker.coerce(service: :faktory, payload: payload, **options)).to eq(worker)
+      end
+    end
+
+    context 'with :sidekiq' do
+      specify do
+        expect(MultiBackgroundJob::Adapters::Sidekiq).to receive(:coerce_to_worker).with(payload, **options).and_return(worker)
+        expect(MultiBackgroundJob::Worker.coerce(service: :sidekiq, payload: payload, **options)).to eq(worker)
+      end
+    end
+
+    context 'with undefined service' do
+      specify do
+        expect{ MultiBackgroundJob::Worker.coerce(service: :invalid, payload: payload, **options) }.to raise_error(KeyError)
+      end
+    end
+  end
+
+  describe '.eql?' do
+    context 'worker class name' do
+      specify do
+        expect(described_class.new('Foo')).to eql(described_class.new('Foo'))
+        expect(described_class.new('Foo')).to eq(described_class.new('Foo'))
+      end
+
+      specify do
+        expect(described_class.new('Bar')).not_to eql(described_class.new('Foo'))
+        expect(described_class.new('Bar')).not_to eq(described_class.new('Foo'))
+      end
+    end
+
+    context 'job content' do
+      specify do
+        expect(described_class.new('Foo').with_args([1])).to eql(described_class.new('Foo').with_args([1]))
+        expect(described_class.new('Foo').with_args([1])).to eq(described_class.new('Foo').with_args([1]))
+      end
+
+      specify do
+        expect(described_class.new('Foo').with_args([1])).not_to eql(described_class.new('Foo').with_args([2]))
+        expect(described_class.new('Foo').with_args([1])).not_to eq(described_class.new('Foo').with_args([2]))
+      end
+    end
+
+    context 'worker options' do
+      specify do
+        expect(described_class.new('Foo', queue: 'foo')).to eql(described_class.new('Foo', queue: 'foo'))
+        expect(described_class.new('Foo', queue: 'foo')).to eq(described_class.new('Foo', queue: 'foo'))
+      end
+
+      specify do
+        expect(described_class.new('Foo', queue: 'foo')).not_to eql(described_class.new('Foo', queue: 'bar'))
+        expect(described_class.new('Foo', queue: 'foo')).not_to eq(described_class.new('Foo', queue: 'bar'))
+      end
+    end
+  end
+end

--- a/spec/multi_background_job_spec.rb
+++ b/spec/multi_background_job_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe MultiBackgroundJob do
+  describe '.[] class method' do
+    after { reset_config! }
+
+    context 'without definition' do
+      specify do
+        described_class.configure { |c| c.strict = false }
+
+        worker = described_class['DummyWorker']
+        expect(worker).to be_an_instance_of(MultiBackgroundJob::Worker)
+        expect(worker.options).to eq({})
+      end
+    end
+
+    context 'with workers definition' do
+      before do
+        MultiBackgroundJob.config.workers = {
+          'DummyWorker' => { 'queue' => 'custom' },
+          'Other' => { 'queue' => 'other' },
+        }
+      end
+
+      it 'loads worker options from global config' do
+        worker = described_class['DummyWorker']
+        expect(worker).to be_an_instance_of(MultiBackgroundJob::Worker)
+        expect(worker.options).to eq(queue: 'custom')
+      end
+
+      it 'does not allow build a worker when strict mode is active' do
+        described_class.configure { |config| config.strict = false }
+        worker = described_class['MissingWorker']
+        expect(worker).to be_an_instance_of(MultiBackgroundJob::Worker)
+
+        described_class.configure { |config| config.strict = true }
+        expect { described_class['MissingWorker'] }.to raise_error(MultiBackgroundJob::NotDefinedWorker)
+      end
+    end
+  end
+
+  describe '.jid class method' do
+    specify do
+      expect(described_class.jid).to be_a_kind_of(String)
+      expect(described_class.jid).not_to eq(described_class.jid)
+      expect(described_class.jid.size).to eq(24)
+    end
+  end
+
+  describe '.config class method' do
+    it { expect(described_class.config).to be_an_instance_of(MultiBackgroundJob::Config) }
+  end
+
+  describe '.configure' do
+    after { reset_config! }
+
+    it 'overwrites default config value' do
+      described_class.config.redis_pool_size = 10
+      described_class.config.redis_pool_timeout = 2
+
+      described_class.configure { |config| config.redis_pool_size = 20 }
+      expect(described_class.config.redis_pool_size).to eq(20)
+      expect(described_class.config.redis_pool_timeout).to eq(2)
+    end
+
+    it 'starts a fresh redis pool' do
+      pool = described_class.redis_pool
+      3.times { expect(described_class.redis_pool).to eql(pool) }
+      described_class.configure { |config| config.redis_pool_size = 1 }
+      expect(described_class.redis_pool).not_to eql(pool)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new DSL to the project to build background job Workers. Initial with the Faktory and Sidekiq adapters

## Example:

Standard job.

```ruby
MultiBackgroundJob['UserWorker', queue: 'default']
    .with_args(1)
    .push(to: :sidekiq)
```

Schedule the time when a job will be executed.
```ruby
MultiBackgroundJob['UserWorker']
    .with_args(1)
    .at(timestamp)
    .push(to: :sidekiq)
  MultiBackgroundJob['UserWorker']
    .with_args(1)
    .in(10.minutes)
    .push(to: :sidekiq)
```

Unique jobs.
```ruby
MultiBackgroundJob['UserWorker', uniq: { across: :queue, timeout: 1.minute, unlock_policy: :start }]
    .with_args(1)
    .push(to: :sidekiq)
```
