### PR TITLE
External Workers API

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -4,5 +4,6 @@ require 'bundler/setup'
 require 'dotenv/load'
 require 'pry'
 require 'awesome_print'
+require 'multi_background_job'
 
 Pry.start

--- a/lib/multi_background_job.rb
+++ b/lib/multi_background_job.rb
@@ -55,10 +55,11 @@ module MultiBackgroundJob
   end
 
   def self.for(service, **options)
-    require_relative "./workers/#{service}"
-
+    require_relative "multi_background_job/workers/#{service}"
+    service = service.to_sym
     worker_options = options.merge(service: service)
-    mod = Workers.const_get(service.to_s.classify)
+    module_name = service.to_s.split(/_/i).collect!{ |w| w.capitalize }.join
+    mod = Workers.const_get(module_name)
     mod.module_eval do
       define_method(:bg_worker_options) do
         worker_options

--- a/lib/multi_background_job/workers/faktory.rb
+++ b/lib/multi_background_job/workers/faktory.rb
@@ -1,0 +1,14 @@
+# frizen_string_literal: true
+
+require_relative './shared_class_methods'
+
+module MultiBackgroundJob
+  module Workers
+    module Faktory
+      def self.included(base)
+        # @TODO Add faktory here
+        base.extend SharedClassMethods
+      end
+    end
+  end
+end

--- a/lib/multi_background_job/workers/shared_class_methods.rb
+++ b/lib/multi_background_job/workers/shared_class_methods.rb
@@ -1,0 +1,26 @@
+# frizen_string_literal: true
+
+module MultiBackgroundJob
+  module Workers
+    module SharedClassMethods
+      def perform_async(*args)
+        build_worker.with_args(*args).push
+      end
+
+      def perform_in(interval, *args)
+        build_worker.with_args(*args).at(interval).push
+      end
+      alias_method :perform_at, :perform_in
+
+      protected
+
+      def service_worker_options
+        {}
+      end
+
+      def build_worker
+        MultiBackgroundJob[self.name, **service_worker_options.merge(bg_worker_options)]
+      end
+    end
+  end
+end

--- a/lib/multi_background_job/workers/sidekiq.rb
+++ b/lib/multi_background_job/workers/sidekiq.rb
@@ -1,0 +1,26 @@
+# frizen_string_literal: true
+
+require_relative './shared_class_methods'
+
+module MultiBackgroundJob
+  module Workers
+    module Sidekiq
+      def self.extended(base)
+        base.include(::Sidekiq::Worker) if defined?(::Sidekiq)
+        base.extend SharedClassMethods
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        def service_worker_options
+          default_queue = ::Sidekiq.default_worker_options['queue'] if defined?(::Sidekiq)
+          default_retry = ::Sidekiq.default_worker_options['retry'] if defined?(::Sidekiq)
+          {
+            queue: (default_queue || 'default'),
+            retry: (default_retry || 15),
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/multi_background_job/workers/sidekiq_spec.rb
+++ b/spec/multi_background_job/workers/sidekiq_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'MultiBackgroundJob::Workers::Sidekiq' do
+  describe 'MultiBackgroundJob#for' do
+    context 'with default settings' do
+      let(:worker) do
+        Class.new do
+          extend MultiBackgroundJob.for(:sidekiq)
+
+          def self.name
+            'DummyWorker'
+          end
+        end
+      end
+
+      specify do
+        expect(worker).to respond_to(:perform_async)
+        expect(worker).to respond_to(:perform_in)
+        expect(worker).to respond_to(:perform_at)
+      end
+
+      specify do
+        expect(worker.service_worker_options).to eq(
+          queue: 'default',
+          retry: 15,
+        )
+      end
+    end
+
+    context 'with global Sidekiq available' do
+      let(:worker_module) { Module.new }
+
+      before do
+        Object.const_set(:Sidekiq, Class.new do
+          def self.default_worker_options
+            {
+              'queue' => 'dummy',
+              'retry' => 0,
+            }
+          end
+        end)
+        Object.const_get(:Sidekiq).const_set(:Worker, worker_module)
+      end
+
+      after do
+        Object.send(:remove_const, :Sidekiq) if Object.constants.include?(:Sidekiq)
+      end
+
+      let(:worker) do
+        Class.new do
+          extend MultiBackgroundJob.for(:sidekiq)
+
+          def self.name
+            'DummyWorker'
+          end
+        end
+      end
+
+      specify do
+        expect(worker).to respond_to(:perform_async)
+        expect(worker).to respond_to(:perform_in)
+        expect(worker).to respond_to(:perform_at)
+      end
+
+      specify do
+        expect(worker.service_worker_options).to eq(
+          queue: 'dummy',
+          retry: 0,
+        )
+      end
+
+      specify do
+        expect(worker.included_modules).to include(worker_module)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds ability to extend jobs and worker classes for the `sidekick` and `faktory` adapters. 