### PR TITLE
Add faktory integration to the list of workers

### DIFF
--- a/lib/multi_background_job/workers/faktory.rb
+++ b/lib/multi_background_job/workers/faktory.rb
@@ -5,9 +5,21 @@ require_relative './shared_class_methods'
 module MultiBackgroundJob
   module Workers
     module Faktory
-      def self.included(base)
-        # @TODO Add faktory here
+      def self.extended(base)
+        base.include(::Faktory::Job) if defined?(::Faktory)
         base.extend SharedClassMethods
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        def service_worker_options
+          default_queue = ::Faktory.default_job_options['queue'] if defined?(::Faktory)
+          default_retry = ::Faktory.default_job_options['retry'] if defined?(::Faktory)
+          {
+            queue: (default_queue || 'default'),
+            retry: (default_retry || 25),
+          }
+        end
       end
     end
   end

--- a/spec/multi_background_job/workers/faktory_spec.rb
+++ b/spec/multi_background_job/workers/faktory_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'MultiBackgroundJob::Workers::Faktory' do
+  describe 'MultiBackgroundJob#for' do
+    context 'with default settings' do
+      let(:worker) do
+        Class.new do
+          extend MultiBackgroundJob.for(:faktory)
+
+          def self.name
+            'DummyWorker'
+          end
+        end
+      end
+
+      specify do
+        expect(worker).to respond_to(:perform_async)
+        expect(worker).to respond_to(:perform_in)
+        expect(worker).to respond_to(:perform_at)
+      end
+
+      specify do
+        expect(worker.service_worker_options).to eq(
+          queue: 'default',
+          retry: 25,
+        )
+      end
+    end
+
+    context 'with global Faktory available' do
+      let(:job_module) { Module.new }
+
+      before do
+        Object.const_set(:Faktory, Class.new do
+          def self.default_job_options
+            {
+              'queue' => 'dummy',
+              'retry' => 0,
+            }
+          end
+        end)
+        Object.const_get(:Faktory).const_set(:Job, job_module)
+      end
+
+      after do
+        Object.send(:remove_const, :Faktory) if Object.constants.include?(:Faktory)
+      end
+
+      let(:worker) do
+        Class.new do
+          extend MultiBackgroundJob.for(:faktory)
+
+          def self.name
+            'DummyWorker'
+          end
+        end
+      end
+
+      specify do
+        expect(worker).to respond_to(:perform_async)
+        expect(worker).to respond_to(:perform_in)
+        expect(worker).to respond_to(:perform_at)
+      end
+
+      specify do
+        expect(worker.service_worker_options).to eq(
+          queue: 'dummy',
+          retry: 0,
+        )
+      end
+
+      specify do
+        expect(worker.included_modules).to include(job_module)
+      end
+    end
+  end
+end

--- a/spec/multi_background_job/workers/faktory_spec.rb
+++ b/spec/multi_background_job/workers/faktory_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe 'MultiBackgroundJob::Workers::Faktory' do
           retry: 25,
         )
       end
+
+      specify do
+        expect(worker.bg_worker_options).to eq({
+          service: :faktory,
+        })
+      end
     end
 
     context 'with global Faktory available' do
@@ -72,7 +78,57 @@ RSpec.describe 'MultiBackgroundJob::Workers::Faktory' do
       end
 
       specify do
+        expect(worker.bg_worker_options).to eq({
+          service: :faktory,
+        })
+      end
+
+      specify do
         expect(worker.included_modules).to include(job_module)
+      end
+    end
+
+    context 'with custom settings' do
+      let(:worker1) do
+        Class.new do
+          extend MultiBackgroundJob.for(:faktory, queue: 'one', retry: 1)
+
+          def self.name
+            'DummyWorkerOne'
+          end
+        end
+      end
+
+      let(:worker2) do
+        Class.new do
+          extend MultiBackgroundJob.for(:faktory, queue: 'two', retry: 2)
+
+          def self.name
+            'DummyWorkerTwo'
+          end
+        end
+      end
+
+      specify do
+        expect(worker1).to respond_to(:perform_async)
+        expect(worker2).to respond_to(:perform_async)
+        expect(worker1).to respond_to(:perform_in)
+        expect(worker2).to respond_to(:perform_in)
+        expect(worker1).to respond_to(:perform_at)
+        expect(worker1).to respond_to(:perform_at)
+      end
+
+      specify do
+        expect(worker1.bg_worker_options).to eq({
+          queue: 'one',
+          retry: 1,
+          service: :faktory,
+        })
+        expect(worker2.bg_worker_options).to eq({
+          queue: 'two',
+          retry: 2,
+          service: :faktory,
+        })
       end
     end
   end


### PR DESCRIPTION
This PR adds the [faktory](https://github.com/contribsys/faktory_worker_ruby) to the list of workers. 

To create a faktory worker you just need to extend the worker/job class using `MultiBackgroundJob.for(:faktory)`

## Examples

Basic setup with defaults

```ruby
class UserWorker
  extend MultiBackgroundJob.for(:faktory)

  def perform(*); end;
end
```

Setup with custom options

```ruby
class UserWorker
  extend MultiBackgroundJob.for(:faktory, queue: 'accounts', retry: 5)

  def perform(*); end;
end
```