### PR TITLE
Refactor Digest Naming

### DIFF
--- a/lib/multi_background_job/adapters/sidekiq.rb
+++ b/lib/multi_background_job/adapters/sidekiq.rb
@@ -105,7 +105,7 @@ module MultiBackgroundJob
         return unless uniqueness?
 
         Lock.new(
-          digest: uniqueness_queue_name,
+          digest: LockDigest.new('sidekiq', queue, across: worker.options.dig(:uniq, :across)).to_s,
           job_id: job_lock_id,
           ttl: now + worker.options.dig(:uniq, :timeout),
         )
@@ -125,22 +125,6 @@ module MultiBackgroundJob
 
       def immediate_queue_name
         "#{namespace}:queue:#{queue}"
-      end
-
-      def uniqueness_queue_name
-        across = worker.options.dig(:uniq, :across)
-        case across
-        when :systemwide
-          "#{namespace}:uniqueness"
-        when :queue
-          "#{namespace}:uniqueness:#{queue}"
-        else
-          raise Error, format(
-            '%<adapter>s can not resolve the uniqueness_queue_name using across %<across>p',
-            adapter: self.class.name,
-            across: across,
-          )
-        end
       end
 
       # This method uses an external queue to control duplications. It has no sidekiq connection.

--- a/lib/multi_background_job/lock_digest.rb
+++ b/lib/multi_background_job/lock_digest.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module MultiBackgroundJob
+  # Class Lock generates the uniq digest acording to the uniq config
+  class LockDigest
+    BASE = 'uniqueness'.freeze
+    SEPARATOR = ':'.freeze
+
+    def initialize(*keys, across:)
+      @keys = keys.map { |k| k.to_s.strip.downcase }
+      @across = across.to_sym
+    end
+
+    def to_s
+      case @across
+      when :systemwide
+        build_name(*@keys.slice(0..-2))
+      when :queue
+        build_name(*@keys)
+      else
+        raise Error, format(
+          'Could not resolve the lock digest using across %<across>p. ' +
+          'Valid options are :systemwide and :queue',
+          across: @across,
+        )
+      end
+    end
+
+    private
+
+    def build_name(*segments)
+      [namespace, BASE, *segments].compact.join(SEPARATOR)
+    end
+
+    def namespace
+      MultiBackgroundJob.config.redis_namespace
+    end
+  end
+end

--- a/spec/multi_background_job/adapters/sidekiq_spec.rb
+++ b/spec/multi_background_job/adapters/sidekiq_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe MultiBackgroundJob::Adapters::Sidekiq do
       standard_name: model.send(:immediate_queue_name),
       scheduled_name: model.send(:scheduled_queue_name),
     }.tap do |h|
-      h[:uniqueness_name] = model.send(:uniqueness_queue_name) if worker.options.key?(:uniq)
+      h[:uniqueness_name] = model.send(:uniqueness_lock).digest if worker.options.key?(:uniq)
     end
   end
 
@@ -79,7 +79,7 @@ RSpec.describe MultiBackgroundJob::Adapters::Sidekiq do
       it { expect(model.send(:uniqueness?)).to eq(true) }
 
       specify do
-        expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness:mailer$/)
+        expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness:sidekiq:mailer$/)
       end
 
       it 'does nothing when set does not exist' do
@@ -138,7 +138,7 @@ RSpec.describe MultiBackgroundJob::Adapters::Sidekiq do
       it { expect(model.send(:uniqueness?)).to eq(true) }
 
       specify do
-        expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness$/)
+        expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness:sidekiq$/)
       end
 
       it 'does nothing when set does not exist' do
@@ -253,7 +253,7 @@ RSpec.describe MultiBackgroundJob::Adapters::Sidekiq do
       end
 
       specify do
-        expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness:mailer$/)
+        expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness:sidekiq:mailer$/)
       end
 
       it 'adds a lock with 1 hour of TTL and enqueues a new job' do
@@ -312,7 +312,7 @@ RSpec.describe MultiBackgroundJob::Adapters::Sidekiq do
       end
 
       specify do
-        expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness$/)
+        expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness:sidekiq$/)
       end
 
       it 'does not push job when active uniqueness lock exist' do

--- a/spec/multi_background_job/lock_digest_spec.rb
+++ b/spec/multi_background_job/lock_digest_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require 'multi_background_job/lock_digest'
+
+RSpec.describe MultiBackgroundJob::LockDigest do
+  describe '.to_s' do
+    context 'without namespace' do
+      before do
+        MultiBackgroundJob.config.redis_namespace = nil
+      end
+
+      after { reset_config! }
+
+      specify do
+        expect(described_class.new('foo', across: :queue).to_s).to eq('uniqueness:foo')
+        expect(described_class.new('sidekiq', 'foo', across: :queue).to_s).to eq('uniqueness:sidekiq:foo')
+      end
+
+      specify do
+        expect(described_class.new('foo', across: :systemwide).to_s).to eq('uniqueness')
+        expect(described_class.new('sidekiq', 'foo', across: :systemwide).to_s).to eq('uniqueness:sidekiq')
+      end
+
+      specify do
+        expect{ described_class.new('foo', across: :undefined).to_s }.to raise_error(
+          MultiBackgroundJob::Error,
+          'Could not resolve the lock digest using across :undefined. Valid options are :systemwide and :queue',
+        )
+        expect{ described_class.new('sidekiq', 'foo', across: :undefined).to_s }.to raise_error(MultiBackgroundJob::Error)
+      end
+    end
+
+    context 'without namespace' do
+      before do
+        MultiBackgroundJob.config.redis_namespace = 'multi-bg-job-test'
+      end
+
+      after { reset_config! }
+
+      specify do
+        expect(described_class.new('foo', across: :queue).to_s).to eq('multi-bg-job-test:uniqueness:foo')
+        expect(described_class.new('sidekiq', 'foo', across: :queue).to_s).to eq('multi-bg-job-test:uniqueness:sidekiq:foo')
+      end
+
+      specify do
+        expect(described_class.new('foo', across: :systemwide).to_s).to eq('multi-bg-job-test:uniqueness')
+        expect(described_class.new('sidekiq', 'foo', across: :systemwide).to_s).to eq('multi-bg-job-test:uniqueness:sidekiq')
+      end
+
+      specify do
+        expect{ described_class.new('foo', across: :undefined).to_s }.to raise_error(
+          MultiBackgroundJob::Error,
+          'Could not resolve the lock digest using across :undefined. Valid options are :systemwide and :queue',
+        )
+        expect{ described_class.new('sidekiq', 'foo', across: :undefined).to_s }.to raise_error(MultiBackgroundJob::Error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Move the logic used to generate the unique naming to a new class named `LockDigest`. Also included the service name to the digest to avoid conflicts with other adapters