### PR TITLE
Middleware to be executed before/after push job

### DIFF
--- a/lib/multi_background_job/config.rb
+++ b/lib/multi_background_job/config.rb
@@ -3,6 +3,8 @@
 require 'redis'
 require 'connection_pool'
 
+require_relative './middleware_chain'
+
 module MultiBackgroundJob
   class Config
     class << self
@@ -73,6 +75,12 @@ module MultiBackgroundJob
         size: redis_pool_size,
         timeout: redis_pool_timeout,
       }
+    end
+
+    def middleware
+      @middleware ||= MiddlewareChain.new
+      yield @middleware if block_given?
+      @middleware
     end
 
     private

--- a/lib/multi_background_job/middleware_chain.rb
+++ b/lib/multi_background_job/middleware_chain.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module MultiBackgroundJob
+  # Middleware is code configured to run before/after a job is processed.
+  # It is patterned after Rack middleware. Middlewares exists to the client side
+  # for some modification before push the job to the server
+  #
+  # To add a middleware:
+  #
+  # MultiBackgroundJob.configure do |config|
+  #   config.middleware do |chain|
+  #     chain.add MyMiddleware
+  #   end
+  # end
+  #
+  # This is an example of a minimal client middleware, note the method must return the result
+  # or the job will not push the server.
+  #
+  # class MyMiddleware
+  #   def call(job, conn_pool)
+  #     puts "Before push"
+  #     result = yield
+  #     puts "After push"
+  #     result
+  #   end
+  # end
+  #
+  class MiddlewareChain
+    include Enumerable
+    attr_reader :entries
+
+    def initialize_copy(copy)
+      copy.instance_variable_set(:@entries, entries.dup)
+    end
+
+    def each(&block)
+      entries.each(&block)
+    end
+
+    def initialize
+      @entries = []
+      yield self if block_given?
+    end
+
+    def remove(klass)
+      entries.delete_if { |entry| entry.klass == klass }
+    end
+
+    def add(klass, *args)
+      remove(klass) if exists?(klass)
+      entries << Entry.new(klass, *args)
+    end
+
+    def prepend(klass, *args)
+      remove(klass) if exists?(klass)
+      entries.insert(0, Entry.new(klass, *args))
+    end
+
+    def insert_before(oldklass, newklass, *args)
+      i = entries.index { |entry| entry.klass == newklass }
+      new_entry = i.nil? ? Entry.new(newklass, *args) : entries.delete_at(i)
+      i = entries.index { |entry| entry.klass == oldklass } || 0
+      entries.insert(i, new_entry)
+    end
+
+    def insert_after(oldklass, newklass, *args)
+      i = entries.index { |entry| entry.klass == newklass }
+      new_entry = i.nil? ? Entry.new(newklass, *args) : entries.delete_at(i)
+      i = entries.index { |entry| entry.klass == oldklass } || entries.count - 1
+      entries.insert(i+1, new_entry)
+    end
+
+    def exists?(klass)
+      any? { |entry| entry.klass == klass }
+    end
+
+    def retrieve
+      map(&:make_new)
+    end
+
+    def clear
+      entries.clear
+    end
+
+    def invoke(*args)
+      chain = retrieve.dup
+      traverse_chain = lambda do
+        if chain.empty?
+          yield
+        else
+          chain.pop.call(*args, &traverse_chain)
+        end
+      end
+      traverse_chain.call
+    end
+
+    class Entry
+      attr_reader :klass, :args
+
+      def initialize(klass, *args)
+        @klass = klass
+        @args  = args
+      end
+
+      def make_new
+        @klass.new(*@args)
+      end
+    end
+  end
+end

--- a/lib/multi_background_job/middleware_chain.rb
+++ b/lib/multi_background_job/middleware_chain.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 module MultiBackgroundJob
-  # Middleware is code configured to run before/after a job is processed.
-  # It is patterned after Rack middleware. Middlewares exists to the client side
-  # for some modification before push the job to the server
+  # Middleware is code configured to run before/after push a new job.
+  # It is patterned after Rack middleware for some modification before push the job to the server
   #
   # To add a middleware:
   #
@@ -13,7 +12,7 @@ module MultiBackgroundJob
   #   end
   # end
   #
-  # This is an example of a minimal client middleware, note the method must return the result
+  # This is an example of a minimal middleware, note the method must return the result
   # or the job will not push the server.
   #
   # class MyMiddleware

--- a/spec/multi_background_job/config_spec.rb
+++ b/spec/multi_background_job/config_spec.rb
@@ -111,4 +111,10 @@ RSpec.describe MultiBackgroundJob::Config do
       expect(config.redis_pool).to eq(timeout: 5, size: 5)
     end
   end
+
+  describe '.middleware' do
+    specify do
+      expect(config.middleware).to be_an_instance_of(MultiBackgroundJob::MiddlewareChain)
+    end
+  end
 end

--- a/spec/multi_background_job/middleware_chain_spec.rb
+++ b/spec/multi_background_job/middleware_chain_spec.rb
@@ -1,0 +1,273 @@
+require 'spec_helper'
+
+RSpec.describe MultiBackgroundJob::MiddlewareChain do
+  let(:model) { described_class.new }
+
+  describe '.add' do
+    let(:middleware) do
+      Class.new { def call(*); end; }
+    end
+
+    specify do
+      expect(model.entries).to eq([])
+      model.add(middleware)
+      expect(model.entries[0]).to be_an_instance_of(described_class::Entry)
+      expect(model.entries[0].klass).to eq(middleware)
+      expect(model.entries[0].args).to eq([])
+    end
+
+    specify do
+      expect(model.entries).to eq([])
+      model.add(middleware, debug: true)
+      expect(model.entries[0]).to be_an_instance_of(described_class::Entry)
+      expect(model.entries[0].klass).to eq(middleware)
+      expect(model.entries[0].args).to eq([{debug: true}])
+    end
+
+    specify do
+      expect(model.entries).to eq([])
+      model.add(middleware)
+      expect(model.entries.size).to eq(1)
+      model.add(middleware)
+      expect(model.entries.size).to eq(1)
+      expect(model.entries[0].args).to eq([])
+      model.add(middleware, debug: true)
+      expect(model.entries.size).to eq(1)
+      expect(model.entries[0].args).to eq([{debug: true}])
+    end
+  end
+
+  describe '.remove' do
+    let(:middleware1) do
+      Class.new { def call(*); end; }
+    end
+    let(:middleware2) do
+      Class.new { def call(*); end; }
+    end
+
+    specify do
+      expect{ model.remove(nil) }.not_to raise_error
+      model.add(middleware2)
+      model.add(middleware1)
+      expect(model.entries.size).to eq(2)
+      expect{ model.remove(middleware1) }.not_to raise_error
+      expect(model.entries.size).to eq(1)
+    end
+  end
+
+  describe '.prepend' do
+    let(:middleware1) do
+      Class.new { def call(*); end; }
+    end
+    let(:middleware2) do
+      Class.new { def call(*); end; }
+    end
+    let(:middleware3) do
+      Class.new { def call(*); end; }
+    end
+
+    specify do
+      model.add(middleware1)
+      model.add(middleware2)
+      expect(model.entries.map(&:klass)).to eq([middleware1, middleware2])
+      expect(model.prepend(middleware3))
+      expect(model.entries.map(&:klass)).to eq([middleware3, middleware1, middleware2])
+    end
+
+    specify do
+      model.add(middleware1)
+      model.add(middleware2)
+      model.add(middleware3)
+      expect(model.entries.map(&:klass)).to eq([middleware1, middleware2, middleware3])
+      expect(model.prepend(middleware3))
+      expect(model.entries.map(&:klass)).to eq([middleware3, middleware1, middleware2])
+    end
+  end
+
+  describe '.insert_before' do
+    let(:middleware1) do
+      Class.new { def call(*); end; }
+    end
+    let(:middleware2) do
+      Class.new { def call(*); end; }
+    end
+    let(:middleware3) do
+      Class.new { def call(*); end; }
+    end
+
+    specify do
+      model.add(middleware1)
+      model.add(middleware2)
+      expect(model.entries.map(&:klass)).to eq([middleware1, middleware2])
+      expect(model.insert_before(middleware2, middleware3))
+      expect(model.entries.map(&:klass)).to eq([middleware1, middleware3, middleware2])
+    end
+
+    specify do
+      model.add(middleware1)
+      expect(model.entries.map(&:klass)).to eq([middleware1])
+      expect(model.insert_before(middleware2, middleware3))
+      expect(model.entries.map(&:klass)).to eq([middleware3, middleware1])
+    end
+
+    specify do
+      model.add(middleware1)
+      model.add(middleware2)
+      model.add(middleware3)
+      expect(model.entries.map(&:klass)).to eq([middleware1, middleware2, middleware3])
+      expect(model.insert_before(middleware2, middleware3))
+      expect(model.entries.map(&:klass)).to eq([middleware1, middleware3, middleware2])
+    end
+  end
+
+  describe '.clear' do
+    let(:middleware1) do
+      Class.new { def call(*); end; }
+    end
+    let(:middleware2) do
+      Class.new { def call(*); end; }
+    end
+
+    before do
+      model.add(middleware1)
+      model.add(middleware2)
+    end
+
+    specify do
+      expect(model.entries.size).to eq(2)
+      model.clear
+      expect(model.entries.size).to eq(0)
+    end
+  end
+
+  describe '.insert_after' do
+    let(:middleware1) do
+      Class.new { def call(*); end; }
+    end
+    let(:middleware2) do
+      Class.new { def call(*); end; }
+    end
+    let(:middleware3) do
+      Class.new { def call(*); end; }
+    end
+
+    specify do
+      model.add(middleware1)
+      model.add(middleware2)
+      expect(model.entries.map(&:klass)).to eq([middleware1, middleware2])
+      expect(model.insert_after(middleware2, middleware3))
+      expect(model.entries.map(&:klass)).to eq([middleware1, middleware2, middleware3])
+    end
+
+    specify do
+      model.add(middleware1)
+      expect(model.entries.map(&:klass)).to eq([middleware1])
+      expect(model.insert_after(middleware2, middleware3))
+      expect(model.entries.map(&:klass)).to eq([middleware1, middleware3])
+    end
+
+    specify do
+      model.add(middleware1)
+      model.add(middleware2)
+      model.add(middleware3)
+      expect(model.entries.map(&:klass)).to eq([middleware1, middleware2, middleware3])
+      expect(model.insert_after(middleware1, middleware3))
+      expect(model.entries.map(&:klass)).to eq([middleware1, middleware3, middleware2])
+    end
+  end
+
+  describe '.exists' do
+    let(:middleware1) do
+      Class.new { def call(*); end; }
+    end
+    let(:middleware2) do
+      Class.new { def call(*); end; }
+    end
+
+    specify do
+      expect(model.exists?(middleware1)).to eq(false)
+      model.add(middleware1)
+      expect(model.exists?(middleware1)).to eq(true)
+      expect(model.exists?(middleware2)).to eq(false)
+    end
+  end
+
+  describe '.retrieve' do
+    let(:middleware_with_args) do
+      Class.new { def initialize(arg); @arg = arg end; }
+    end
+    let(:middleware_without_args) do
+      Class.new { def initialize(); end; }
+    end
+
+    specify do
+      model.add(middleware_without_args)
+      expect(model.retrieve[0]).to be_an_instance_of(middleware_without_args)
+    end
+
+    specify do
+      model.add(middleware_with_args, 'ok')
+      expect(model.retrieve[0]).to be_an_instance_of(middleware_with_args)
+      expect(model.retrieve[0].instance_variable_get(:@arg)).to eq('ok')
+    end
+  end
+
+  describe '.invoke' do
+    let(:middleware1) do
+      Class.new do
+        def call(arg)
+          result = yield
+          result.push(arg)
+          result
+        end
+      end
+    end
+
+    let(:middleware2) do
+      Class.new do
+        def call(arg)
+          return false if arg == 3
+
+          result = yield
+          result.push(arg + 1)
+          result
+        end
+      end
+    end
+
+    specify do
+      model.add(middleware1)
+      executed = false
+      result = model.invoke(1) do
+        executed = true
+        []
+      end
+      expect(executed).to eq(true)
+      expect(result).to eq([1])
+    end
+
+    specify do
+      model.add(middleware1)
+      model.add(middleware2)
+      executed = false
+      result = model.invoke(1) do
+        executed = true
+        []
+      end
+      expect(executed).to eq(true)
+      expect(result).to eq([1, 2])
+    end
+
+    specify do
+      model.add(middleware1)
+      model.add(middleware2)
+      executed = false
+      result = model.invoke(3) do
+        executed = true
+        []
+      end
+      expect(executed).to eq(false)
+      expect(result).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Middleware is code configured to run before/after push a new job. It is patterned after Rack middleware for some modification before push the job to the server
  
To add a middleware:
```ruby
  MultiBackgroundJob.configure do |config|
    config.middleware do |chain|
      chain.add MyMiddleware
    end
  end
```
  
This is an example of a minimal middleware, note the method must return the result or the job will not push the server.

```ruby
  class MyMiddleware
    def call(job, conn_pool)
      puts "Before push"
      result = yield
      puts "After push"
      result
    end
  end
```