### PR TITLE
Refactor UniqueJob Manage

### DIFF
--- a/lib/multi_background_job/unique_job.rb
+++ b/lib/multi_background_job/unique_job.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module MultiBackgroundJob
+  class UniqueJob
+    VALID_OPTIONS = {
+      across: %i[queue systemwide],
+      timeout: 604800, # 1 week
+      unlock_policy: %i[success start],
+    }.freeze
+
+    attr_reader :across, :timeout, :unlock_policy
+
+    # @options [Hash] Unique definitions
+    # @option [Symbol] :across Valid options are :queue and :systemwide. If jobs should not to be duplicated on
+    #   current queue or the entire system
+    # @option [Integer] :timeout Amount of times in seconds. Timeout decides how long to wait for acquiring the lock.
+    #   A default timeout is defined to 1 week so unique locks won't last forever.
+    # @option [Symbol] :unlock_policy Control when the unique lock is removed. The default value is `success`.
+    #   The job will not unlock until it executes successfully, it will remain locked even if it raises an error and
+    #   goes into the retry queue. The alternative value is `start` the job will unlock right before it starts executing
+    def initialize(across: :queue, timeout: nil, unlock_policy: :success)
+      unless VALID_OPTIONS[:across].include?(across.to_sym)
+        raise Error, format('Invalid `across: %<given>p` option. Only %<expected>p are allowed.',
+          given: across,
+          expected: VALID_OPTIONS[:across])
+      end
+      unless VALID_OPTIONS[:unlock_policy].include?(unlock_policy.to_sym)
+        raise Error, format('Invalid `unlock_policy: %<given>p` option. Only %<expected>p are allowed.',
+          given: unlock_policy,
+          expected: VALID_OPTIONS[:unlock_policy])
+      end
+      timeout = VALID_OPTIONS[:timeout] if timeout.to_i <= 0
+
+      @across = across.to_sym
+      @timeout = timeout.to_i
+      @unlock_policy = unlock_policy.to_sym
+    end
+
+    def to_hash
+      {
+        across: across,
+        timeout: timeout,
+        unlock_policy: unlock_policy,
+      }
+    end
+
+    def as_json
+      to_hash.each_with_object({}) do |(key, val), memo|
+        memo[key.to_s] = val.is_a?(Symbol) ? val.to_s : val
+      end
+    end
+
+    def eql?(other)
+      [across, timeout, unlock_policy] == [other.across, other.timeout, other.unlock_policy]
+    end
+    alias == eql?
+  end
+end

--- a/spec/multi_background_job/adapters/sidekiq_spec.rb
+++ b/spec/multi_background_job/adapters/sidekiq_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe MultiBackgroundJob::Adapters::Sidekiq do
       standard_name: model.send(:immediate_queue_name),
       scheduled_name: model.send(:scheduled_queue_name),
     }.tap do |h|
-      h[:uniqueness_name] = model.send(:uniqueness_lock).digest if worker.options.key?(:uniq)
+      h[:uniqueness_name] = model.send(:uniqueness_lock).digest if worker.unique_job
     end
   end
 
@@ -51,7 +51,7 @@ RSpec.describe MultiBackgroundJob::Adapters::Sidekiq do
     let(:now) { Time.now.to_f }
 
     context 'with a standard job' do
-      it { expect(model.send(:uniqueness?)).to eq(false) }
+      it { expect(model.send(:unique_job_enabled?)).to eq(false) }
 
       it 'does dothing' do
         expect(MultiBackgroundJob.redis_pool).not_to receive(:with)
@@ -76,7 +76,7 @@ RSpec.describe MultiBackgroundJob::Adapters::Sidekiq do
         conn.del(redis_dataset[:uniqueness_name])
       end
 
-      it { expect(model.send(:uniqueness?)).to eq(true) }
+      it { expect(model.send(:unique_job_enabled?)).to eq(true) }
 
       specify do
         expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness:sidekiq:mailer$/)
@@ -135,7 +135,7 @@ RSpec.describe MultiBackgroundJob::Adapters::Sidekiq do
         conn.del(redis_dataset[:uniqueness_name])
       end
 
-      it { expect(model.send(:uniqueness?)).to eq(true) }
+      it { expect(model.send(:unique_job_enabled?)).to eq(true) }
 
       specify do
         expect(redis_dataset[:uniqueness_name]).to match(/:uniqueness:sidekiq$/)

--- a/spec/multi_background_job/unique_job_spec.rb
+++ b/spec/multi_background_job/unique_job_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe MultiBackgroundJob::UniqueJob do
+
+  let(:across_option) { :queue }
+  let(:timeout_option) { WEEK_IN_SECONDS }
+  let(:unlock_policy_option) { :success }
+
+  describe '.initialize' do
+    context 'without arguments' do
+      specify do
+        model = described_class.new
+        expect(model.across).to eq(across_option)
+        expect(model.timeout).to eq(timeout_option)
+        expect(model.unlock_policy).to eq(unlock_policy_option)
+      end
+    end
+
+    context 'with custom :across option' do
+      specify do
+        expect { described_class.new(across: :invalid) }.to raise_error(
+          MultiBackgroundJob::Error, 'Invalid `across: :invalid` option. Only [:queue, :systemwide] are allowed.'
+        )
+      end
+
+      specify do
+        model = described_class.new(across: :queue)
+        expect(model.across).to eq(:queue)
+      end
+
+      specify do
+        model = described_class.new(across: :systemwide)
+        expect(model.across).to eq(:systemwide)
+      end
+
+      specify do
+        model = described_class.new(across: 'systemwide')
+        expect(model.across).to eq(:systemwide)
+      end
+    end
+
+    context 'with custom :unlock_policy option' do
+      specify do
+        expect { described_class.new(unlock_policy: :invalid) }.to raise_error(
+          MultiBackgroundJob::Error, 'Invalid `unlock_policy: :invalid` option. Only [:success, :start] are allowed.'
+        )
+      end
+
+      specify do
+        model = described_class.new(unlock_policy: :success)
+        expect(model.unlock_policy).to eq(:success)
+      end
+
+      specify do
+        model = described_class.new(unlock_policy: :start)
+        expect(model.unlock_policy).to eq(:start)
+      end
+
+      specify do
+        model = described_class.new(unlock_policy: 'start')
+        expect(model.unlock_policy).to eq(:start)
+      end
+    end
+
+    context 'with custom :timeout option' do
+      specify do
+        model = described_class.new(timeout: -1 )
+        expect(model.timeout).to eq(timeout_option)
+      end
+
+      specify do
+        model = described_class.new(timeout: 10)
+        expect(model.timeout).to eq(10)
+      end
+    end
+  end
+
+  describe '.to_hash' do
+    subject { model.to_hash }
+
+    context 'with default options' do
+      let(:model) { described_class.new }
+
+      specify do
+        is_expected.to eq(
+          across: across_option,
+          timeout: timeout_option,
+          unlock_policy: unlock_policy_option,
+        )
+      end
+    end
+
+    context 'with custom options' do
+      let(:model) { described_class.new(across: 'systemwide', timeout: 10, unlock_policy: 'start') }
+
+      specify do
+        is_expected.to eq(
+          across: :systemwide,
+          timeout: 10,
+          unlock_policy: :start,
+        )
+      end
+    end
+  end
+
+  describe '.as_json' do
+    subject { model.as_json }
+
+    context 'with default options' do
+      let(:model) { described_class.new }
+
+      specify do
+        is_expected.to eq(
+          'across' => across_option.to_s,
+          'timeout' => timeout_option,
+          'unlock_policy' => unlock_policy_option.to_s,
+        )
+      end
+    end
+
+    context 'with custom options' do
+      let(:model) { described_class.new(across: 'systemwide', timeout: 10, unlock_policy: 'start') }
+
+      specify do
+        is_expected.to eq(
+          'across' => 'systemwide',
+          'timeout' => 10,
+          'unlock_policy' => 'start',
+        )
+      end
+    end
+  end
+
+  describe '.eql?' do
+    specify do
+      expect(described_class.new(across: 'systemwide', timeout: 10, unlock_policy: 'start')).to eq(
+        described_class.new(across: 'systemwide', timeout: 10, unlock_policy: 'start')
+      )
+    end
+
+    specify do
+      expect(described_class.new(across: 'systemwide', timeout: 10, unlock_policy: :start)).to eq(
+        described_class.new(across: :systemwide, timeout: 10, unlock_policy: 'start')
+      )
+    end
+
+    specify do
+      expect(described_class.new(across: :queue, timeout: 10, unlock_policy: :start)).not_to eq(
+        described_class.new(across: :systemwide, timeout: 10, unlock_policy: 'start')
+      )
+    end
+
+    specify do
+      expect(described_class.new(across: :systemwide, timeout: 11, unlock_policy: :start)).not_to eq(
+        described_class.new(across: :systemwide, timeout: 10, unlock_policy: 'start')
+      )
+    end
+
+    specify do
+      expect(described_class.new(across: :systemwide, timeout: 10, unlock_policy: :success)).not_to eq(
+        described_class.new(across: :systemwide, timeout: 10, unlock_policy: :start)
+      )
+    end
+  end
+end

--- a/spec/multi_background_job/worker_spec.rb
+++ b/spec/multi_background_job/worker_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe MultiBackgroundJob::Worker do
     end
   end
 
-  describe '.setup_uniq_option' do
+  describe '.unique_job' do
     let(:defaults) do
       {
         across: :queue,
@@ -118,28 +118,28 @@ RSpec.describe MultiBackgroundJob::Worker do
       worker = described_class.new('DummyWorker')
       expect(worker.job).to eq({})
       expect(worker.options).to eq({})
+      expect(worker.unique_job).to eq(nil)
     end
 
     specify do
       worker = described_class.new('DummyWorker', uniq: {})
       expect(worker.job).to eq({})
-      expect(worker.options).to eq(
-        uniq: defaults
-      )
+      expect(worker.options).to eq({})
+      expect(worker.unique_job).to be_an_instance_of(MultiBackgroundJob::UniqueJob)
     end
 
     specify do
       worker = described_class.new('DummyWorker', uniq: true)
       expect(worker.job).to eq({})
-      expect(worker.options).to eq(
-        uniq: defaults
-      )
+      expect(worker.options).to eq({})
+      expect(worker.unique_job).to be_an_instance_of(MultiBackgroundJob::UniqueJob)
     end
 
     specify do
       worker = described_class.new('DummyWorker', uniq: false)
       expect(worker.job).to eq({})
       expect(worker.options).to eq({})
+      expect(worker.unique_job).to eq(nil)
     end
 
     context 'with custom :across option' do
@@ -151,24 +151,24 @@ RSpec.describe MultiBackgroundJob::Worker do
 
       specify do
         worker = described_class.new('DummyWorker', uniq: { across: :queue })
-        expect(worker.options).to eq(uniq: defaults)
-        expect(worker.job).to eq({})
+        expect(worker.options).to eq({})
+        expect(worker.unique_job).to be_an_instance_of(MultiBackgroundJob::UniqueJob)
+        expect(worker.unique_job.across).to eq(:queue)
       end
 
       specify do
         worker = described_class.new('DummyWorker', uniq: { across: :systemwide })
         expect(worker.job).to eq({})
-        expect(worker.options).to eq(
-          uniq: defaults.merge(across: :systemwide),
-        )
+        expect(worker.options).to eq({})
+        expect(worker.unique_job).to be_an_instance_of(MultiBackgroundJob::UniqueJob)
+        expect(worker.unique_job.across).to eq(:systemwide)
       end
 
       specify do
         worker = described_class.new('DummyWorker', uniq: { across: 'systemwide' })
         expect(worker.job).to eq({})
-        expect(worker.options).to eq(
-          uniq: defaults.merge(across: :systemwide),
-        )
+        expect(worker.options).to eq({})
+        expect(worker.unique_job.across).to eq(:systemwide)
       end
     end
 
@@ -182,23 +182,25 @@ RSpec.describe MultiBackgroundJob::Worker do
       specify do
         worker = described_class.new('DummyWorker', uniq: { unlock_policy: :success })
         expect(worker.job).to eq({})
-        expect(worker.options).to eq(uniq: defaults)
+        expect(worker.options).to eq({})
+        expect(worker.unique_job).to be_an_instance_of(MultiBackgroundJob::UniqueJob)
+        expect(worker.unique_job.unlock_policy).to eq(:success)
       end
 
       specify do
         worker = described_class.new('DummyWorker', uniq: { unlock_policy: :start })
         expect(worker.job).to eq({})
-        expect(worker.options).to eq(
-          uniq: defaults.merge(unlock_policy: :start)
-        )
+        expect(worker.options).to eq({})
+        expect(worker.unique_job).to be_an_instance_of(MultiBackgroundJob::UniqueJob)
+        expect(worker.unique_job.unlock_policy).to eq(:start)
       end
 
       specify do
         worker = described_class.new('DummyWorker', uniq: { unlock_policy: 'start' })
         expect(worker.job).to eq({})
-        expect(worker.options).to eq(
-          uniq: defaults.merge(unlock_policy: :start)
-        )
+        expect(worker.options).to eq({})
+        expect(worker.unique_job).to be_an_instance_of(MultiBackgroundJob::UniqueJob)
+        expect(worker.unique_job.unlock_policy).to eq(:start)
       end
     end
 
@@ -206,17 +208,17 @@ RSpec.describe MultiBackgroundJob::Worker do
       specify do
         worker = described_class.new('DummyWorker', uniq: { timeout: -1 })
         expect(worker.job).to eq({})
-        expect(worker.options).to eq(
-          uniq: defaults
-        )
+        expect(worker.options).to eq({})
+        expect(worker.unique_job).to be_an_instance_of(MultiBackgroundJob::UniqueJob)
+        expect(worker.unique_job.timeout).to eq(defaults[:timeout])
       end
 
       specify do
         worker = described_class.new('DummyWorker', uniq: { timeout: 10 })
         expect(worker.job).to eq({})
-        expect(worker.options).to eq(
-          uniq: defaults.merge(timeout: 10)
-        )
+        expect(worker.options).to eq({})
+        expect(worker.unique_job).to be_an_instance_of(MultiBackgroundJob::UniqueJob)
+        expect(worker.unique_job.timeout).to eq(10)
       end
     end
   end


### PR DESCRIPTION
This PR moves the responsability of unique job control to a new model named `UniqueJob`. This should avoid code duplications across background job adapters.